### PR TITLE
New child adds link with description

### DIFF
--- a/org-brain.el
+++ b/org-brain.el
@@ -196,14 +196,14 @@ You can choose to EXCLUDE an entry from the list."
         (make-directory (file-name-directory entry-path) t)))
     (or (org-map-entries (lambda ()
                            (end-of-line)
-                           (insert (format "\n- [[brain:%s][%s]]" child child))
+                           (insert (format "\n- [[brain:%s][%s]]" child (org-brain-title child)))
                            (save-buffer))
                          "+brainchildren"
                          (list entry-path))
         (with-current-buffer (get-file-buffer entry-path)
           (goto-char (point-max))
           (insert (format "\n\n* %s    :brainchildren:\n- [[brain:%s][%s]]"
-                          org-brain-children-headline-default-name child child))
+                          org-brain-children-headline-default-name child (org-brain-title child)))
           (save-buffer)))))
 (defun org-brain-insert-visualize-button (entry)
   "Insert a button, which runs `org-brain-visualize' on ENTRY when clicked."

--- a/org-brain.el
+++ b/org-brain.el
@@ -205,6 +205,7 @@ You can choose to EXCLUDE an entry from the list."
           (insert (format "\n\n* %s    :brainchildren:\n- [[brain:%s][%s]]"
                           org-brain-children-headline-default-name child (org-brain-title child)))
           (save-buffer)))))
+
 (defun org-brain-insert-visualize-button (entry)
   "Insert a button, which runs `org-brain-visualize' on ENTRY when clicked."
   (insert-text-button

--- a/org-brain.el
+++ b/org-brain.el
@@ -189,14 +189,14 @@ You can choose to EXCLUDE an entry from the list."
         (make-directory (file-name-directory entry-path) t)))
     (or (org-map-entries (lambda ()
                            (end-of-line)
-                           (insert (format "\n- [[brain:%s]]" child))
+                           (insert (format "\n- [[brain:%s][%s]]" child child))
                            (save-buffer))
                          "+brainchildren"
                          (list entry-path))
         (with-current-buffer (get-file-buffer entry-path)
           (goto-char (point-max))
-          (insert (format "\n\n* %s    :brainchildren:\n- [[brain:%s]]"
-                          org-brain-children-headline-default-name child))
+          (insert (format "\n\n* %s    :brainchildren:\n- [[brain:%s][%s]]"
+                          org-brain-children-headline-default-name child child))
           (save-buffer)))))
 
 (defun org-brain-insert-visualize-button (entry)


### PR DESCRIPTION
In order to have consistent behaviour between the link creating functions I suggest that `org-brain-new-child` automatically adds also a link description instead of just the bare link.