### PR TITLE
More visualize interface functionality

### DIFF
--- a/README.org
+++ b/README.org
@@ -125,12 +125,13 @@ Once in the org-brain-visualize interface/mode, via =M-x org-brain-visualize=, y
    once separated by =org-brain-batch-separator=, ";" by default, to
    simultaneously create more than one.
 4. "P" to pin the current entry (if it is already pinned, then =org-brain= will respect that)
-5. "r" to rename the current entry
+5. "R" to remove a pin from the current entry
+6. "r" to rename the current entry
    This will only change the filename and entry name, not the =#+TITLE= of
    the entry.
-6. "t" to add or change the title of the current entry
+7. "t" to add or change the title of the current entry
    This will create a new title, prompting you for the value. If a
-   title, #+TITLE: some-title, already exists then it will replace it with the
+   title, #+TITLE: some-title, already exists then it will be replaced with the
    new title you've provide.
 
 Here is the the full list of keybindings:
@@ -140,6 +141,7 @@ Here is the the full list of keybindings:
 | c         | Add child                             |
 | p         | Add parent                            |
 | P         | Add pin                               |
+| R         | Remove pin                            |
 | t         | Add or change title                   |
 | l         | Add resource link                     |
 | C-y       | Paste resource link                   |

--- a/README.org
+++ b/README.org
@@ -80,6 +80,26 @@ here's the steps to install it manually:
      (eval-after-load 'evil
        (evil-set-initial-state 'org-brain-visualize-mode 'emacs)))
    #+end_src
+6. If you want to eagerly build some of the caches (rather than wait to have
+   them built automatically in a lazy way), you may use =org-brain-build-caches=
+   either interactively or programatically, perhaps during Emacs startup time
+   (while you get your coffee). You'll be adding about 15 seconds to Emacs
+   startup time in exchange for the same savings of save on your initial use of
+   org-brain. Example configuration for this:
+   #+begin_src emacs-lisp
+    (use-package org-brain
+      ;; :ensure t ; Pull request not yet in MELPA package
+      :load-path "~/.ghq/github.com/analyticd/org-brain"
+      :init
+      (setq org-brain-path "/path/to/where/you/want/to/keep/your/org/brain/files/or/your/existing/org/files/directory")
+      (eval-after-load 'evil
+        (evil-set-initial-state 'org-brain-visualize-mode 'emacs))
+      ;; Prebuild some of the org-brain caches during Emacs startup at the cost of
+      ;; slower Emacs startup time.
+      (org-brain-build-caches))
+   #+end_src
+   Using =org-brain-build-caches= isn't necessary as, again, the caches are built
+   automatically in a lazy way during use of the org-brain-visualize interface.
 
 * Usage
 

--- a/README.org
+++ b/README.org
@@ -1,8 +1,14 @@
 #+TITLE:org-brain [[http://melpa.org/#/org-brain][file:http://melpa.org/packages/org-brain-badge.svg]]
 
-=org-brain= implements a variant of [[https://en.wikipedia.org/wiki/Concept_map][concept mapping]] in Emacs, using [[http://orgmode.org/][org-mode]]. It is heavily inspired by a piece of software called [[http://thebrain.com/][The Brain]] (but currently with a more limited feature set), you can view an introduction to that program [[https://www.youtube.com/watch?v=GFqLUBKCFdA][here]].
+=org-brain= implements a variant of [[https://en.wikipedia.org/wiki/Concept_map][concept mapping]] in Emacs, using [[http://orgmode.org/][org-mode]]. It
+is heavily inspired by a piece of software called [[http://thebrain.com/][The Brain]] (but currently with
+a more limited feature set), you can view an introduction to that program [[https://www.youtube.com/watch?v=GFqLUBKCFdA][here]].
 
-You can think of =org-brain= as a combination of a wiki and a mind map, where each wiki page / mind-map node is an =org-mode= file which resides in your =org-brain-path= (a directory containing all your =org-brain= files). These files are called /entries/. Entries can link to other entries, and you can then view the network of links as a mind map, using =M-x org-brain-visualize=.
+You can think of =org-brain= as a combination of a wiki and a mind map, where each
+wiki page / mind-map node is an =org-mode= file which resides in your
+=org-brain-path= (a directory containing all your =org-brain= files). These files
+are called /entries/. Entries can link to other entries, and you can then view the
+network of links as a mind map, using =M-x org-brain-visualize=.
 
 #+BEGIN_EXAMPLE
 PINNED:  Index
@@ -30,32 +36,91 @@ Game Maker  Unity
 /* Brainchildren
 #+END_EXAMPLE
 
-Above is a visualization of the /game programming/ entry (as can be seen in the middle). Above the entry title we can see that the entry has two parents (other entries which link to game programming): /programming/ and /game development/. You can also see the siblings and which parent they come from: /python/, /programming books/, /emacs/, and /game design/. Below the entry title we can see the children of the entry: /Game Maker/ and /Unity/. At the very top you'll find pinned entries (entries which will be shown independent of the visualized entry).
+Above is a visualization of the /game programming/ entry (as can be seen in the
+middle). Above the entry title we can see that the entry has two parents (other
+entries which link to game programming): /programming/ and /game development/. You
+can also see the siblings and which parent they come from: /python/, /programming
+books/, /emacs/, and /game design/. Below the entry title we can see the children of
+the entry: /Game Maker/ and /Unity/. At the very top you'll find pinned entries
+(entries which will be shown independent of the visualized entry).
 
-At the bottom the entry's table of contents (headlines in the buffer) is shown: /Gamasutra Articles/ and /Brainchildren/. You can also see the resources of the entry: the two Gamasutra articles and the Wikipedia link. Resources can be =org-mode= links in the entry file, or [[http://orgmode.org/manual/Attachments.html][org attachments]].
+At the bottom the entry's table of contents (headlines in the buffer) is shown:
+/Gamasutra Articles/ and /Brainchildren/. You can also see the resources of the
+entry: the two Gamasutra articles and the Wikipedia link. Resources can be
+=org-mode= links in the entry file, or [[http://orgmode.org/manual/Attachments.html][org attachments]].
 
-The parents, children, siblings, headlines and resources are all links; they can be pressed to visualize other entries, visit resources etc.
+The parents, children, siblings, headlines and resources are all links; they can
+be pressed to visualize other entries, visit resources etc.
 
 * Setup and requirements
 
-The easiest way is to get =org-brain= from MELPA. If you do not want to do that, here's the steps to install it manually:
+The easiest way is to get =org-brain= from MELPA. If you do not want to do that or
+would like this fork which includes caching and an extended visualize interface,
+here's the steps to install it manually:
 
-1. =org-brain= requires Emacs 25, org-mode 9 and [[https://github.com/magnars/dash.el][dash]]. These need to be part of your Emacs.
-2. Download =org-brain.el=, add it to your load-path, and put =(require 'org-brain)= in your init-file.
-3. Configure =org-brain-path= (defaults to =/brain= in your =org-directory=) to a directory where you want to put your =org-brain= files.
+1. =org-brain= requires Emacs 25, org-mode 9. These need to be part of your Emacs.
+2. Clone the repo locally (plug for [[https://github.com/motemen/ghq][ghq]] to manage local repo cloning).
+3. Utilize =use-package= to load the repo. (Alternatively, download =org-brain.el=, add it to your load-path, and put =(require 'org-brain)= in your init-file.)
+   #+begin_src emacs-lisp
+   (use-package org-brain
+     ;; :ensure t ; If you want to use MELPA package which doesn't include the caching and extended visualize interface.
+     :load-path "~/.ghq/github.com/analyticd/org-brain"
+     :init
+     (setq org-brain-path "/path/to/where/you/want/to/keep/your/org/brain/files/or/just/your/existing/org/files/directory"))
+   #+end_src
+4. Configure =org-brain-path= (defaults to =/brain= in your =org-directory=) to a directory where you want to put your =org-brain= files (which could be the location where you already keep your org files if you wish to transform your existing org files into =org-brain= files)
+   You can set this with the example config presented above or through the customize interface, 
+5. If you are an evil user, you'll want to add =(evil-set-initial-state 'org-brain-visualize-mode 'emacs)= to your =org-brain= configuration. Here is the config example above, updated:
+   #+begin_src emacs-lisp
+   (use-package org-brain
+     ;; :ensure t ; If you want to use MELPA package which doesn't include the caching and extended visualize interface.
+     :load-path "~/.ghq/github.com/analyticd/org-brain"
+     :init
+     (setq org-brain-path "/path/to/where/you/want/to/keep/your/org/brain/files/or/your/existing/org/files/directory")
+     (eval-after-load 'evil
+       (evil-set-initial-state 'org-brain-visualize-mode 'emacs)))
+   #+end_src
 
 * Usage
 
-You can use =M-x org-brain-open= to open an entry (or create a new one) in your =org-brain= for editing. In order to link to other entries, use an =org-mode= link with =brain:= type, its easiest to use =C-c C-l brain: TAB= or =M-x org-brain-insert-link=. If you want to pin an entry, add a line =#+BRAIN_PIN:= in the entry file.
+Primarily you should interact with the =M-x org-brain-visualize= interface in order to benefit from automatic caching and thus dramatic speed gains (~30x faster).
 
-=M-x org-brain-agenda= can be used to run =org-agenda= on your =org-brain= files. You might also want to rename one of your entries; use =M-x org-brain-rename-entry= to do this. This will only change the filename and entry name, not the =#+TITLE= of the entry.
+Once in the org-brain-visualize interface/mode, via =M-x org-brain-visualize=, you can type:
 
-You can use =M-x org-brain-visualize= to choose an entry which will be visualized. While in =org-brain-visualize-mode= you can easily navigate your =org-brain=, add children/parents etc, using the following keybindings:
+1. "o" to open the current entry in your =org-brain= for editing.
+2. "c" to create a child for the current entry. You may enter several children at
+   once separated by =org-brain-batch-separator=, ";" by default, to
+   simultaneously create more than one. For instance pressing =c= and then =guitar;
+   mandolin;banjo= would add =guitar=, =mandolin= and =banjo= as children. Currently
+   it isn't possible to use completion when batch entering children/parents, so
+   it is best used for adding non-existing entries.
+   
+   If you add children to a file with =org-brain-visualize=, the links to the child
+   entries will be added under the first headline in the file with the
+   =brainchildren= tag. If this headline doesn't exist, a headline named
+   /Brainchildren/ will be created and will be given the tag. If you want another
+   default name for these headlines, you can customize
+   =org-brain-children-headline-default-name=.
+3. "p" to create a parent for the current entry. You may enter several parents at
+   once separated by =org-brain-batch-separator=, ";" by default, to
+   simultaneously create more than one.
+4. "P" to pin the current entry (if it is already pinned, then =org-brain= will respect that)
+5. "r" to rename the current entry
+   This will only change the filename and entry name, not the =#+TITLE= of
+   the entry.
+6. "t" to add or change the title of the current entry
+   This will create a new title, prompting you for the value. If a
+   title, #+TITLE: some-title, already exists then it will replace it with the
+   new title you've provide.
+
+Here is the the full list of keybindings:
 
 | j / TAB   | Goto next link                        |
 | k / S-TAB | Goto previous link                    |
 | c         | Add child                             |
 | p         | Add parent                            |
+| P         | Add pin                               |
+| t         | Add or change title                   |
 | l         | Add resource link                     |
 | C-y       | Paste resource link                   |
 | a         | Add resource [[http://orgmode.org/manual/Attachments.html][attachment]]               |
@@ -63,15 +128,36 @@ You can use =M-x org-brain-visualize= to choose an entry which will be visualize
 | f         | Find/visit another entry to visualize |
 | r         | Rename this, or another, entry        |
 
-When adding children or parents using =org-brain-visualize=, you can add multiple entries by using =org-brain-batch-separator=, =;= by default, to separate the entries. For instance pressing =c= and then =guitar; mandolin;banjo= would add =guitar=, =mandolin= and =banjo= as children. Currently it isn't possible to use completion when batch entering children/parents, so it is best used for adding non-existing entries.
+In order to link to other entries, use an =org-mode= link
+with =brain:= type, its easiest to use =C-c C-l brain: TAB= or =M-x
+org-brain-insert-link=. 
 
-If you add children to a file with =org-brain-visualize=, the links to the child entries will be added under the first headline in the file with the =brainchildren= tag. If this headline doesn't exist, a headline named /Brainchildren/ will be created and will be given the tag. If you want another default name for these headlines, you can customize =org-brain-children-headline-default-name=.
+=M-x org-brain-agenda= can be used to run =org-agenda= on your =org-brain= files. 
 
-If you add resources via =org-brain-visualize= they will be entered inserted under the current heading in the visualize buffer (link resource will be added as list items at the top of the heading in the entry file). If you're not under a heading in the visualize buffer, the resources will be added to /Brainchildren/, as in the case with adding new children.
+
+If you add resources via =org-brain-visualize= they will be entered inserted under
+the current heading in the visualize buffer (link resource will be added as list
+items at the top of the heading in the entry file). If you're not under a
+heading in the visualize buffer, the resources will be added to /Brainchildren/,
+as in the case with adding new children.
+
+Editing /Brainchildren/ manually is off the golden path. If you edit /Brainchildren/
+manually, i.e., outside the =org-brain-visualize= interface, then the caches will
+be inconsistent with actual state on disk. To remedy this situation, you may use
+=M-x org-brain-invalidate-all-caches= after making such edits. Subsequently the
+caches will be rebuilt and speed of the org-brain-visualize interface/mode will
+become very fast again after an initial cache miss (which will cause the caches
+to be built). =org-brain-files= cache is built all at once on first cache miss
+while org-brain-children-cache, org-brain-parents-cache, and
+org-brain-pins-cache are necessarily built node by node. Subsequent returns to
+said cached nodes will be approximately 30x faster.
 
 * Other useful packages
 
-There's some missing functionality in =org-brain=, which could be useful, especially regarding finding text etc. However, there are many other packages for =org-mode= which might implement some of the features you seek. Below are some suggestions (feel free to create an issue or send a pull request if you have more examples).
+There's some missing functionality in =org-brain=, which could be useful,
+especially regarding finding text, etc.. However, there are many other packages
+for which might be useful alternatives. Below are some suggestions (feel free to
+create an issue or send a pull request if you have more examples).
 
 ** [[http://jblevins.org/projects/deft/][deft]]
 
@@ -107,11 +193,19 @@ You can add the function below to your init-file.
 #+END_SRC
 
 ** [[https://github.com/scallywag/org-board][org-board]]
-
 #+BEGIN_QUOTE
 org-board is a bookmarking and web archival system for Emacs Org mode, building on ideas from Pinboard. It archives your bookmarks so that you can access them even when you're not online, or when the site hosting them goes down.
 #+END_QUOTE
-
-* Disclaimer
-
-=org-brain= is a new package, and it may have speed issues if the number of org-mode entries get high (I haven't tried it with thousands of entries).
+** [[https://github.com/gregdetre/emacs-freex][emacs-freex]]
+Emacs freex is a Pymacs/SQLite/Elisp system that implements a transcluding wiki.
+Emacs-freex is not compatible at this time with org-mode. Despite this,
+emacs-freex is an impressive system for maintaining a wiki. Further, because the
+data is stored both in files on disk and in an SQLite database, it opens the
+possibility for implementing something like =org-brain='s visualize interface (ala
+TheBrain's "plex") by talking with SQLite, via Pymacs, to return the
+relationships between nodes. This would consistute a lot of work to implement
+but would be very impressive. If someone was to also add LaTeX rendering inside
+=emacs-freex= =nuggets= also, those two additional features would make =emacs-freex=
+more compelling. As it is, practically speaking, you may think of =org-brain= as
+implementing many of the features of =emacs-freex=, but with all of =org-mode='s
+goodness included.

--- a/org-brain.el
+++ b/org-brain.el
@@ -698,7 +698,7 @@ PARENT can hold multiple entries, by using `org-brain-batch-separator'."
     (with-current-buffer (find-file-noselect entry-path)
       (when (not (assoc "BRAIN_PIN" (org-brain-keywords entry)))
         (goto-char (point-min))
-        (insert "\n#+BRAIN_PIN:\n")
+        (insert "#+BRAIN_PIN:\n")
         (save-buffer)))))
 
 (defun org-brain-visualize-remove-pin ()
@@ -742,7 +742,7 @@ PARENT can hold multiple entries, by using `org-brain-batch-separator'."
       (if (not (assoc "TITLE" (org-brain-keywords entry)))
           (progn
             (goto-char (point-min))
-            (insert (format "\n#+TITLE: %s\n" title))
+            (insert (format "#+TITLE: %s\n" title))
             (save-buffer))
         ;; Remove #+TITLE: ... and create new one
         (progn
@@ -752,7 +752,7 @@ PARENT can hold multiple entries, by using `org-brain-batch-separator'."
           (when (looking-at "^#\\+TITLE: +.*$")
             (kill-line)
             (goto-char (point-min))
-            (insert (format "\n#+TITLE: %s\n" title))
+            (insert (format "#+TITLE: %s\n" title))
             (save-buffer)))))))
 
 (define-derived-mode org-brain-visualize-mode

--- a/org-brain.el
+++ b/org-brain.el
@@ -75,7 +75,7 @@ This will be used by `org-brain-new-child'."
           (t (setf node (cdr node))))))
 
 ;;; Logging
-(defcustom org-brain-log t
+(defcustom org-brain-log nil
   "Set to nil to not write to *Messages* buffer."
   :group 'org-brain
   :type 'boolean)

--- a/org-brain.el
+++ b/org-brain.el
@@ -123,6 +123,17 @@ This will be used by `org-brain-new-child'."
   (org-brain-log "Invalidating org-brain pin cache...")
   (setq org-brain-pins-cache nil))
 
+(defun org-brain-build-caches ()
+  "(Optional) It is not necessary to use this function as the
+  caches are built lazily, automatically. However, this is just
+  here if you want to do some cache building ahead of time, for
+  instance during Emacs startup (at the cost of a longer Emacs
+  startup) while you grab your coffee."
+  (interactive)
+  (org-brain-log "Eagerly building some of the org-brain caches..")
+  (org-brain-files)
+  (org-brain-pins))
+
 (defun org-brain-files (&optional relative)
   "Get all org files (recursively) in `org-brain-path'.
 If RELATIVE is t, then return relative paths and remove org extension."

--- a/org-brain.el
+++ b/org-brain.el
@@ -664,7 +664,8 @@ CHILD can hold multiple entries, by using `org-brain-batch-separator'."
   (interactive
    (list (completing-read "Child: " (org-brain-files t))))
   (org-brain-invalidate-files-cache)    ; Invalidate cache
-  (org-brain-invalidate-child-cache-entry org-brain--visualizing-entry) ; Invalidate cache
+  (org-brain-invalidate-child-cache-entry
+   org-brain--visualizing-entry)        ; Invalidate cache
   (dolist (c (split-string child org-brain-batch-separator t " +"))
     (org-brain-new-child org-brain--visualizing-entry c))
   (when (string-equal (buffer-name) "*org-brain*")
@@ -676,7 +677,8 @@ PARENT can hold multiple entries, by using `org-brain-batch-separator'."
   (interactive
    (list (completing-read "Parent: " (org-brain-files t))))
   (org-brain-invalidate-files-cache)    ; Invalidate cache
-  (org-brain-invalidate-parent-cache-entry org-brain--visualizing-entry) ; Invalidate cache
+  (org-brain-invalidate-parent-cache-entry
+   org-brain--visualizing-entry)        ; Invalidate cache
   (dolist (p (split-string parent org-brain-batch-separator t " +"))
     (org-brain-new-child p org-brain--visualizing-entry))
   (when (string-equal (buffer-name) "*org-brain*")

--- a/org-brain.el
+++ b/org-brain.el
@@ -725,9 +725,12 @@ PARENT can hold multiple entries, by using `org-brain-batch-separator'."
 
 (defun org-brain-visualize-add-or-change-title ()
   "In current org-brain ENTRY, add \"#+TITLE:\" with title value acquired
-  from user."
+  and required from user."
   (interactive)
   (let ((title (read-string "Title: ")))
+    (loop while (empty-string-p title) do
+          (setq title (read-string
+                       "Title must have a value, please enter title: ")))
     (org-brain-add-or-change-title title org-brain--visualizing-entry)
     (when (string-equal (buffer-name) "*org-brain*")
       (revert-buffer))))

--- a/org-brain.el
+++ b/org-brain.el
@@ -110,12 +110,14 @@ This will be used by `org-brain-new-child'."
   (setq org-brain-files-cache nil))
 
 (defun org-brain-invalidate-parent-cache-entry (entry)
-  (org-brain-log (format "Invalidating org-brain parent cache entry: %s ..." entry))
+  (org-brain-log
+   (format "Invalidating org-brain parent cache entry: %s ..." entry))
   (setq org-brain-parents-cache
         (remove* entry org-brain-parents-cache :test #'equal :key #'car)))
 
 (defun org-brain-invalidate-child-cache-entry (entry)
-  (org-brain-log (format "Invalidating org-brain child cache entry: %s ..." entry))
+  (org-brain-log
+   (format "Invalidating org-brain child cache entry: %s ..." entry))
   (setq org-brain-children-cache
         (remove* entry org-brain-children-cache :test #'equal :key #'car)))
 
@@ -204,7 +206,6 @@ If RELATIVE is t, then return relative paths and remove org extension."
 (defun org-brain-children (entry &optional exclude)
   "Get list of org-brain entries linked to from ENTRY.
 You can choose to EXCLUDE an entry from the list."
-  ;; TODO Handle exclude
   (if (and org-brain-children-cache
            (assoc entry org-brain-children-cache))
       (cdr (assoc entry org-brain-children-cache))


### PR DESCRIPTION
* Added eager caching possibility to be used at Emacs startup time as an option.
* Set logging of caching messages to *Messages* buffer off by default
* Added remove pin functionality to visualize interface with keybinding
* Ensure user supplies non nil and non empty string title value for add or change title functionality
* Updated README for same