### PR TITLE
Bug fix of org brain new child

### DIFF
--- a/README.org
+++ b/README.org
@@ -124,30 +124,36 @@ Once in the org-brain-visualize interface/mode, via =M-x org-brain-visualize=, y
    default name for these headlines, you can customize
    =org-brain-children-headline-default-name=.
 3. "C" to remove a child (link) for the current entry. This does not delete the
-   file pointed to by the child (link).
+   file pointed to by the child (link). You may enter several children at
+   once separated by =org-brain-batch-separator=, ";" by default, to
+   simultaneously remove more than one.
 4. "p" to create a parent for the current entry. You may enter several parents at
    once separated by =org-brain-batch-separator=, ";" by default, to
    simultaneously create more than one.
-5. "P" to pin the current entry (if it is already pinned, then =org-brain= will respect that)
-6. "R" to remove a pin from the current entry
-7. "r" to rename the current entry
+5. "P" to remove a parent for the current entry. You may enter several parents at
+   once separated by =org-brain-batch-separator=, ";" by default, to
+   simultaneously remove more than one.
+6. "n" to pin the current entry (if it is already pinned, then =org-brain= will respect that)
+7. "N" to remove a pin from the current entry
+8. "r" to rename the current entry
    This will only change the filename and entry name, not the =#+TITLE= of
    the entry.
-8. "t" to add or change the title of the current entry
+9. "t" to add or change the title of the current entry
    This will create a new title, prompting you for the value. If a
    title, #+TITLE: some-title, already exists then it will be replaced with the
    new title you've provide.
-9. "T" to remove a title of the current entry altogether.
+10. "T" to remove a title of the current entry altogether.
 
 Here is the the full list of keybindings:
 
 | j / TAB   | Goto next link                        |
 | k / S-TAB | Goto previous link                    |
-| c         | Add child                             |
-| C         | Remove child                          |
-| p         | Add parent                            |
-| P         | Add pin                               |
-| R         | Remove pin                            |
+| c         | Add child(ren)                        |
+| C         | Remove child(ren)                     |
+| p         | Add parent(s)                         |
+| P         | Remove parent(s)                      |
+| n         | Add pin                               |
+| N         | Remove pin                            |
 | t         | Add or change title                   |
 | T         | Remove title                          |
 | l         | Add resource link                     |

--- a/README.org
+++ b/README.org
@@ -103,7 +103,9 @@ here's the steps to install it manually:
 
 * Usage
 
-Primarily you should interact with the =M-x org-brain-visualize= interface in order to benefit from automatic caching and thus dramatic speed gains (~30x faster).
+Primarily you should interact with the =M-x org-brain-visualize= interface in
+order to benefit from automatic caching and thus dramatic speed gains (~30x
+faster).
 
 Once in the org-brain-visualize interface/mode, via =M-x org-brain-visualize=, you can type:
 

--- a/README.org
+++ b/README.org
@@ -125,12 +125,13 @@ Once in the org-brain-visualize interface/mode, via =M-x org-brain-visualize=, y
    once separated by =org-brain-batch-separator=, ";" by default, to
    simultaneously create more than one.
 4. "P" to pin the current entry (if it is already pinned, then =org-brain= will respect that)
-5. "r" to rename the current entry
+5. "R" to remove a pin from the current entry
+6. "r" to rename the current entry
    This will only change the filename and entry name, not the =#+TITLE= of
    the entry.
-6. "t" to add or change the title of the current entry
+7. "t" to add or change the title of the current entry
    This will create a new title, prompting you for the value. If a
-   title, #+TITLE: some-title, already exists then it will replace it with the
+   title, #+TITLE: some-title, already exists then it will be replaced with the
    new title you've provide.
 
 Here is the the full list of keybindings:
@@ -140,6 +141,7 @@ Here is the the full list of keybindings:
 | c         | Add child                             |
 | p         | Add parent                            |
 | P         | Add pin                               |
+| R         | Remove pin                            |
 | t         | Add or change title                   |
 | l         | Add resource link                     |
 | C-y       | Paste resource link                   |

--- a/README.org
+++ b/README.org
@@ -80,6 +80,26 @@ here's the steps to install it manually:
      (eval-after-load 'evil
        (evil-set-initial-state 'org-brain-visualize-mode 'emacs)))
    #+end_src
+6. If you want to eagerly build some of the caches (rather than wait to have
+   them built automatically in a lazy way), you may use =org-brain-build-caches=
+   either interactively or programatically, perhaps during Emacs startup time
+   (while you get your coffee). You'll be adding about 15 seconds to Emacs
+   startup time in exchange for the same savings of save on your initial use of
+   org-brain. Example configuration for this:
+   #+begin_src emacs-lisp
+    (use-package org-brain
+      ;; :ensure t ; Pull request not yet in MELPA package
+      :load-path "~/.ghq/github.com/analyticd/org-brain"
+      :init
+      (setq org-brain-path "/path/to/where/you/want/to/keep/your/org/brain/files/or/your/existing/org/files/directory")
+      (eval-after-load 'evil
+        (evil-set-initial-state 'org-brain-visualize-mode 'emacs))
+      ;; Prebuild some of the org-brain caches during Emacs startup at the cost of
+      ;; slower Emacs startup time.
+      (org-brain-build-caches))
+   #+end_src
+   Using =org-brain-build-caches= isn't necessary as, again, the caches are built
+   automatically in a lazy way during use of the org-brain-visualize interface.
 
 * Usage
 

--- a/README.org
+++ b/README.org
@@ -156,7 +156,6 @@ org-brain-insert-link=.
 
 =M-x org-brain-agenda= can be used to run =org-agenda= on your =org-brain= files. 
 
-
 If you add resources via =org-brain-visualize= they will be entered inserted under
 the current heading in the visualize buffer (link resource will be added as list
 items at the top of the heading in the entry file). If you're not under a
@@ -170,8 +169,8 @@ be inconsistent with actual state on disk. To remedy this situation, you may use
 caches will be rebuilt and speed of the org-brain-visualize interface/mode will
 become very fast again after an initial cache miss (which will cause the caches
 to be built). =org-brain-files= cache is built all at once on first cache miss
-while org-brain-children-cache, org-brain-parents-cache, and
-org-brain-pins-cache are necessarily built node by node. Subsequent returns to
+while =org-brain-children-cache=, =org-brain-parents-cache=, and
+=org-brain-pins-cache= are necessarily built node by node. Subsequent returns to
 said cached nodes will be approximately 30x faster.
 
 * Other useful packages

--- a/README.org
+++ b/README.org
@@ -135,6 +135,7 @@ Once in the org-brain-visualize interface/mode, via =M-x org-brain-visualize=, y
    This will create a new title, prompting you for the value. If a
    title, #+TITLE: some-title, already exists then it will be replaced with the
    new title you've provide.
+8. "T" to remove a title of the current entry altogether.
 
 Here is the the full list of keybindings:
 
@@ -145,6 +146,7 @@ Here is the the full list of keybindings:
 | P         | Add pin                               |
 | R         | Remove pin                            |
 | t         | Add or change title                   |
+| T         | Remove title                          |
 | l         | Add resource link                     |
 | C-y       | Paste resource link                   |
 | a         | Add resource [[http://orgmode.org/manual/Attachments.html][attachment]]               |

--- a/README.org
+++ b/README.org
@@ -123,25 +123,28 @@ Once in the org-brain-visualize interface/mode, via =M-x org-brain-visualize=, y
    /Brainchildren/ will be created and will be given the tag. If you want another
    default name for these headlines, you can customize
    =org-brain-children-headline-default-name=.
-3. "p" to create a parent for the current entry. You may enter several parents at
+3. "C" to remove a child (link) for the current entry. This does not delete the
+   file pointed to by the child (link).
+4. "p" to create a parent for the current entry. You may enter several parents at
    once separated by =org-brain-batch-separator=, ";" by default, to
    simultaneously create more than one.
-4. "P" to pin the current entry (if it is already pinned, then =org-brain= will respect that)
-5. "R" to remove a pin from the current entry
-6. "r" to rename the current entry
+5. "P" to pin the current entry (if it is already pinned, then =org-brain= will respect that)
+6. "R" to remove a pin from the current entry
+7. "r" to rename the current entry
    This will only change the filename and entry name, not the =#+TITLE= of
    the entry.
-7. "t" to add or change the title of the current entry
+8. "t" to add or change the title of the current entry
    This will create a new title, prompting you for the value. If a
    title, #+TITLE: some-title, already exists then it will be replaced with the
    new title you've provide.
-8. "T" to remove a title of the current entry altogether.
+9. "T" to remove a title of the current entry altogether.
 
 Here is the the full list of keybindings:
 
 | j / TAB   | Goto next link                        |
 | k / S-TAB | Goto previous link                    |
 | c         | Add child                             |
+| C         | Remove child                          |
 | p         | Add parent                            |
 | P         | Add pin                               |
 | R         | Remove pin                            |

--- a/org-brain.el
+++ b/org-brain.el
@@ -698,7 +698,7 @@ PARENT can hold multiple entries, by using `org-brain-batch-separator'."
     (with-current-buffer (find-file-noselect entry-path)
       (when (not (assoc "BRAIN_PIN" (org-brain-keywords entry)))
         (goto-char (point-min))
-        (insert "\n#+BRAIN_PIN:\n")
+        (insert "#+BRAIN_PIN:\n")
         (save-buffer)))))
 
 (defun org-brain-visualize-remove-pin ()
@@ -742,7 +742,7 @@ PARENT can hold multiple entries, by using `org-brain-batch-separator'."
       (if (not (assoc "TITLE" (org-brain-keywords entry)))
           (progn
             (goto-char (point-min))
-            (insert (format "\n#+TITLE: %s\n" title))
+            (insert (format "#+TITLE: %s\n" title))
             (save-buffer))
         ;; Remove #+TITLE: ... and create new one
         (progn
@@ -752,7 +752,7 @@ PARENT can hold multiple entries, by using `org-brain-batch-separator'."
           (when (looking-at "^#\\+TITLE: +.*$")
             (kill-line)
             (goto-char (point-min))
-            (insert (format "\n#+TITLE: %s\n" title))
+            (insert (format "#+TITLE: %s\n" title))
             (save-buffer)))))))
 
 (define-derived-mode org-brain-visualize-mode

--- a/org-brain.el
+++ b/org-brain.el
@@ -75,7 +75,7 @@ This will be used by `org-brain-new-child'."
           (t (setf node (cdr node))))))
 
 ;;; Logging
-(defcustom org-brain-log t
+(defcustom org-brain-log nil
   "Set to nil to not write to *Messages* buffer."
   :group 'org-brain
   :type 'boolean)

--- a/org-brain.el
+++ b/org-brain.el
@@ -369,7 +369,7 @@ NEWENTRY. The ENTRY file will also be renamed."
          (read-string "New name: ")))
   (let ((oldfile (org-brain-entry-path entry))
         (newfile (org-brain-entry-path newname)))
-    (org-brain-invalidate-files-cache)    ; NOTE Invalidate org-brain file cache
+    (org-brain-invalidate-files-cache)  ; Invalidate cache
     (mapc
      (lambda (brainfile)
        (with-temp-buffer

--- a/org-brain.el
+++ b/org-brain.el
@@ -336,17 +336,14 @@ You can choose to EXCLUDE an entry from the list."
           (save-excursion
             (re-search-forward
              (format "^\\*.*:%s:.*$" org-brain-children-tag-default-name) nil t)
-            (let ((bound (outline-next-heading)))
-              (re-search-backward
-               (format "^\\*.*:%s:.*$" org-brain-children-tag-default-name) nil t)
-              (beginning-of-line)
-              (re-search-forward
-               (format "^ *- \\[\\[brain:%s.*$" child-to-remove) bound t)
-              (beginning-of-line)
-              (looking-at (format "^ *- \\[\\[brain:%s.*$" child-to-remove))
-              (kill-line 1)
-              (save-buffer)
-              (org-brain-invalidate-child-cache-entry entry)))))))
+            (beginning-of-line)
+            (re-search-forward
+             (format "^ *- \\[\\[brain:%s.*$" child-to-remove) nil t)
+            (beginning-of-line)
+            (looking-at (format "^ *- \\[\\[brain:%s.*$" child-to-remove))
+            (kill-line 1)
+            (save-buffer)
+            (org-brain-invalidate-child-cache-entry entry))))))
 
 (defun org-brain-insert-visualize-button (entry)
   "Insert a button, which runs `org-brain-visualize' on ENTRY when clicked."

--- a/org-brain.el
+++ b/org-brain.el
@@ -99,10 +99,10 @@ This will be used by `org-brain-new-child'."
     (setq inhibit-message nil)))
 
 ;;; Caches
-(setq org-brain-files-cache nil)
-(setq org-brain-parents-cache nil)
-(setq org-brain-children-cache nil)
-(setq org-brain-pins-cache nil)
+(defvar org-brain-files-cache nil "Cache for org-brain-files")
+(defvar org-brain-parents-cache nil "Cache for org-brain-parents")
+(defvar org-brain-children-cache nil "Cache for org-brain-children")
+(defvar org-brain-pins-cache nil "Cache for org-brain-pins")
 
 ;;;###autoload
 (defun org-brain-invalidate-all-caches ()

--- a/org-brain.el
+++ b/org-brain.el
@@ -123,6 +123,17 @@ This will be used by `org-brain-new-child'."
   (org-brain-log "Invalidating org-brain pin cache...")
   (setq org-brain-pins-cache nil))
 
+(defun org-brain-build-caches ()
+  "(Optional) It is not necessary to use this function as the
+  caches are built lazily, automatically. However, this is just
+  here if you want to do some cache building ahead of time, for
+  instance during Emacs startup (at the cost of a longer Emacs
+  startup) while you grab your coffee."
+  (interactive)
+  (org-brain-log "Eagerly building some of the org-brain caches..")
+  (org-brain-files)
+  (org-brain-pins))
+
 (defun org-brain-files (&optional relative)
   "Get all org files (recursively) in `org-brain-path'.
 If RELATIVE is t, then return relative paths and remove org extension."

--- a/org-brain.el
+++ b/org-brain.el
@@ -664,7 +664,8 @@ CHILD can hold multiple entries, by using `org-brain-batch-separator'."
   (interactive
    (list (completing-read "Child: " (org-brain-files t))))
   (org-brain-invalidate-files-cache)    ; Invalidate cache
-  (org-brain-invalidate-child-cache-entry org-brain--visualizing-entry) ; Invalidate cache
+  (org-brain-invalidate-child-cache-entry
+   org-brain--visualizing-entry)        ; Invalidate cache
   (dolist (c (split-string child org-brain-batch-separator t " +"))
     (org-brain-new-child org-brain--visualizing-entry c))
   (when (string-equal (buffer-name) "*org-brain*")
@@ -676,7 +677,8 @@ PARENT can hold multiple entries, by using `org-brain-batch-separator'."
   (interactive
    (list (completing-read "Parent: " (org-brain-files t))))
   (org-brain-invalidate-files-cache)    ; Invalidate cache
-  (org-brain-invalidate-parent-cache-entry org-brain--visualizing-entry) ; Invalidate cache
+  (org-brain-invalidate-parent-cache-entry
+   org-brain--visualizing-entry)        ; Invalidate cache
   (dolist (p (split-string parent org-brain-batch-separator t " +"))
     (org-brain-new-child p org-brain--visualizing-entry))
   (when (string-equal (buffer-name) "*org-brain*")

--- a/org-brain.el
+++ b/org-brain.el
@@ -189,27 +189,26 @@ If RELATIVE is t, then return relative paths and remove org extension."
   (if (and org-brain-parents-cache
            (assoc entry org-brain-parents-cache))
       (cdr (assoc entry org-brain-parents-cache))
-    (progn
-      (org-brain-log (format  "Updating org-brain-parents-cache for %s..." entry))
-      (let ((parents (remove nil
-                      (mapcar
-                       (lambda (brainfile)
-                         (let ((brainfile-entry (org-brain-path-entry-name brainfile)))
-                           (unless (string-equal brainfile-entry entry)
-                             (org-element-map
-                                 (with-temp-buffer
-                                   (insert-file-contents brainfile)
-                                   (org-element-parse-buffer))
-                                 'link
-                               (lambda (link)
-                                 (when (and (string-equal (org-element-property :type link) "brain")
-                                            (string-equal (car (split-string (org-element-property :path link) "::"))
-                                                          entry))
-                                   brainfile-entry))
-                               nil t))))
-                       (org-brain-files)))))
-        (push (cons entry . (parents)) org-brain-parents-cache)
-        (cdr (assoc entry org-brain-parents-cache))))))
+    (org-brain-log (format  "Updating org-brain-parents-cache for %s..." entry))
+    (let ((parents (remove nil
+                           (mapcar
+                            (lambda (brainfile)
+                              (let ((brainfile-entry (org-brain-path-entry-name brainfile)))
+                                (unless (string-equal brainfile-entry entry)
+                                  (org-element-map
+                                      (with-temp-buffer
+                                        (insert-file-contents brainfile)
+                                        (org-element-parse-buffer))
+                                      'link
+                                    (lambda (link)
+                                      (when (and (string-equal (org-element-property :type link) "brain")
+                                                 (string-equal (car (split-string (org-element-property :path link) "::"))
+                                                               entry))
+                                        brainfile-entry))
+                                    nil t))))
+                            (org-brain-files)))))
+      (push (cons entry . (parents)) org-brain-parents-cache)
+      (cdr (assoc entry org-brain-parents-cache)))))
 
 (defun org-brain-children (entry &optional exclude)
   "Get list of org-brain entries linked to from ENTRY.

--- a/org-brain.el
+++ b/org-brain.el
@@ -725,9 +725,12 @@ PARENT can hold multiple entries, by using `org-brain-batch-separator'."
 
 (defun org-brain-visualize-add-or-change-title ()
   "In current org-brain ENTRY, add \"#+TITLE:\" with title value acquired
-  from user."
+  and required from user."
   (interactive)
   (let ((title (read-string "Title: ")))
+    (loop while (empty-string-p title) do
+          (setq title (read-string
+                       "Title must have a value, please enter title: ")))
     (org-brain-add-or-change-title title org-brain--visualizing-entry)
     (when (string-equal (buffer-name) "*org-brain*")
       (revert-buffer))))

--- a/org-brain.el
+++ b/org-brain.el
@@ -756,6 +756,27 @@ PARENT can hold multiple entries, by using `org-brain-batch-separator'."
             (insert (format "#+TITLE: %s\n" title))
             (save-buffer))))))
 
+(defun org-brain-visualize-remove-title ()
+  "Remove \"#+TITLE:\" line from entry last visited by
+  `org-brain-visualize' if it exists."
+  (interactive)
+  (org-brain-remove-title org-brain--visualizing-entry)
+  (when (string-equal (buffer-name) "*org-brain*")
+    (revert-buffer)))
+
+(defun org-brain-remove-title (entry)
+  "In org-brain ENTRY, remove \"#+TITLE:\" if it exists."
+  (let ((entry-path (org-brain-entry-path entry)))
+    (org-save-all-org-buffers)
+    (with-current-buffer (find-file-noselect entry-path)
+      (when (assoc "TITLE" (org-brain-keywords entry))
+        (goto-char (point-min))
+        (re-search-forward "^#\\+TITLE:.*$")
+        (beginning-of-line)
+        (when (looking-at "^#\\+TITLE:.*$")
+            (kill-line)
+            (save-buffer))))))
+
 (define-derived-mode org-brain-visualize-mode
   special-mode  "Org-brain Visualize"
   "Major mode for `org-brain-visualize'.
@@ -767,6 +788,7 @@ PARENT can hold multiple entries, by using `org-brain-batch-separator'."
 (define-key org-brain-visualize-mode-map "P" 'org-brain-visualize-add-pin)
 (define-key org-brain-visualize-mode-map "R" 'org-brain-visualize-remove-pin)
 (define-key org-brain-visualize-mode-map "t" 'org-brain-visualize-add-or-change-title)
+(define-key org-brain-visualize-mode-map "T" 'org-brain-visualize-remove-title)
 (define-key org-brain-visualize-mode-map "j" 'forward-button)
 (define-key org-brain-visualize-mode-map "k" 'backward-button)
 (define-key org-brain-visualize-mode-map [?\t] 'forward-button)

--- a/org-brain.el
+++ b/org-brain.el
@@ -66,7 +66,7 @@ This will be used by `org-brain-new-child'."
 
 ;;; Utils
 (defun org-brain-flatten (obj)
-  "Return a 1-dimensional list, OBJ, given an n-dimensional list."
+  "Return a 1-dimensional list, given an n-dimensional list OBJ."
   (do* ((result (list obj))
         (node result))
        ((null node) (delete nil result))

--- a/org-brain.el
+++ b/org-brain.el
@@ -142,6 +142,7 @@ This will be used by `org-brain-new-child'."
   (org-brain-log "Invalidating org-brain pin cache...")
   (setq org-brain-pins-cache nil))
 
+;;;###autoload
 (defun org-brain-build-caches ()
   "(Optional) It is not necessary to use this function as the
   caches are built lazily, automatically. However, this is just
@@ -330,12 +331,14 @@ You can choose to EXCLUDE an entry from the list."
     (let ((child-to-remove
            (completing-read "Child to remove: "
             (org-brain-children entry))))
-      (with-current-buffer (get-file-buffer entry-path)
+      (with-current-buffer (find-file-noselect entry-path)
           (goto-char (point-min))
           (save-excursion
-            (re-search-forward (format "^\\*.*:%s:.*$" org-brain-children-tag-default-name) nil t)
+            (re-search-forward
+             (format "^\\*.*:%s:.*$" org-brain-children-tag-default-name) nil t)
             (let ((bound (outline-next-heading)))
-              (re-search-backward (format "^\\*.*:%s:.*$" org-brain-children-tag-default-name) nil t)
+              (re-search-backward
+               (format "^\\*.*:%s:.*$" org-brain-children-tag-default-name) nil t)
               (beginning-of-line)
               (re-search-forward
                (format "^ *- \\[\\[brain:%s.*$" child-to-remove) bound t)

--- a/org-brain.el
+++ b/org-brain.el
@@ -307,26 +307,31 @@ You can choose to EXCLUDE an entry from the list."
     (unless (file-exists-p entry-path)
       (with-temp-file entry-path
         (make-directory (file-name-directory entry-path) t)))
-    (or (org-map-entries (lambda ()
-                           (end-of-line)
-                           (insert (format "\n- [[brain:%s][%s]]" child (org-brain-title child)))
-                           (save-buffer))
-                         (format "+%s" org-brain-children-tag-default-name)
-                         (list entry-path))
-        (with-current-buffer (get-file-buffer entry-path)
+    (with-current-buffer (find-file-noselect entry-path)
+      (goto-char (point-min))
+      (save-excursion
+        (if (re-search-forward
+               (format "^\\*.*:%s:.*$" org-brain-children-tag-default-name)
+               nil t)
+            (progn
+              (end-of-line)
+              (insert (format "\n- [[brain:%s][%s]]"
+                              child (org-brain-title child)))
+              (save-buffer))
           (goto-char (point-max))
           (insert (format "\n\n* %s    :%s:\n- [[brain:%s][%s]]"
-                          org-brain-children-tag-default-name
                           org-brain-children-headline-default-name
+                          org-brain-children-tag-default-name
                           child
                           (org-brain-title child)))
-          (save-buffer)))))
+          (save-buffer))))))
 
 (defun org-brain-remove-child (entry child)
   "In org-brain ENTRY, remove CHILD link. This doesn't delete the
   file pointed to by the link, just the link."
   (let ((entry-path (org-brain-entry-path entry)))
     (org-save-all-org-buffers)
+    (org-brain-invalidate-child-cache-entry entry)
     (with-current-buffer (find-file-noselect entry-path)
       (goto-char (point-min))
       (save-excursion
@@ -338,8 +343,7 @@ You can choose to EXCLUDE an entry from the list."
         (beginning-of-line)
         (looking-at (format "^ *- \\[\\[brain:%s.*$" child))
         (kill-line 1)
-        (save-buffer)
-        (org-brain-invalidate-child-cache-entry entry)))))
+        (save-buffer)))))
 
 (defun org-brain-insert-visualize-button (entry)
   "Insert a button, which runs `org-brain-visualize' on ENTRY when clicked."
@@ -708,7 +712,6 @@ CHILD can hold multiple entries, by using `org-brain-batch-separator'."
    org-brain--visualizing-entry)        ; Invalidate cache
   (dolist (c (split-string child org-brain-batch-separator t " +"))
     (org-brain-remove-child org-brain--visualizing-entry c))
-  ;; (org-brain-remove-child org-brain--visualizing-entry)
   (when (string-equal (buffer-name) "*org-brain*")
     (revert-buffer)))
 

--- a/org-brain.el
+++ b/org-brain.el
@@ -110,12 +110,14 @@ This will be used by `org-brain-new-child'."
   (setq org-brain-files-cache nil))
 
 (defun org-brain-invalidate-parent-cache-entry (entry)
-  (org-brain-log (format "Invalidating org-brain parent cache entry: %s ..." entry))
+  (org-brain-log
+   (format "Invalidating org-brain parent cache entry: %s ..." entry))
   (setq org-brain-parents-cache
         (remove* entry org-brain-parents-cache :test #'equal :key #'car)))
 
 (defun org-brain-invalidate-child-cache-entry (entry)
-  (org-brain-log (format "Invalidating org-brain child cache entry: %s ..." entry))
+  (org-brain-log
+   (format "Invalidating org-brain child cache entry: %s ..." entry))
   (setq org-brain-children-cache
         (remove* entry org-brain-children-cache :test #'equal :key #'car)))
 
@@ -204,7 +206,6 @@ If RELATIVE is t, then return relative paths and remove org extension."
 (defun org-brain-children (entry &optional exclude)
   "Get list of org-brain entries linked to from ENTRY.
 You can choose to EXCLUDE an entry from the list."
-  ;; TODO Handle exclude
   (if (and org-brain-children-cache
            (assoc entry org-brain-children-cache))
       (cdr (assoc entry org-brain-children-cache))


### PR DESCRIPTION
org-brain-new-child had a bug where it would add a the child once or even multiple times to not only the :brainchildren: headline, but to every headline in a file. This is now fixed. The fix results in faster performance too as it uses regex api.