### PR TITLE
Fixed links with the format [[URL][URL]]

### DIFF
--- a/org-brain.el
+++ b/org-brain.el
@@ -468,7 +468,7 @@ is (raw-link description)."
                                         attachment)))
                           (org-attach-file-list attach-dir)))))))
          ;; Links
-	 (cl-delete-if
+	 (cl-remove-if
 	  ;; we want to delete elements which for some reason `org-element-contents' does not return
 	  ;; a string or nil. I think is a non-desired behaviour from `org-element-parse-buffer'.
 	  (lambda (elt)

--- a/org-brain.el
+++ b/org-brain.el
@@ -484,9 +484,7 @@ is (raw-link description)."
 			 (goto-char (org-element-property :begin link))
 			 (ignore-errors (org-get-heading t t)))
 		       (list (org-element-property :raw-link link)
-			     (car (org-element-contents link))))))))
-
-		       ))))))))))
+			     (car (org-element-contents link))))))))))))))
 
 (defun org-brain-insert-resource-button (resource &optional indent)
   "Insert a new line with a RESOURCE button, indented by INDENT spaces."

--- a/org-brain.el
+++ b/org-brain.el
@@ -468,15 +468,25 @@ is (raw-link description)."
                                         attachment)))
                           (org-attach-file-list attach-dir)))))))
          ;; Links
-         (delete-dups
-          (org-element-map data 'link
-            (lambda (link)
-              (unless (member (org-element-property :type link) org-brain-ignored-resource-links)
-                (cons (progn
-                        (goto-char (org-element-property :begin link))
-                        (ignore-errors (org-get-heading t t)))
-                      (list (org-element-property :raw-link link)
-                            (car (org-element-contents link)))))))))))))
+	 (cl-delete-if
+	  ;; we want to delete elements which for some reason `org-element-contents' does not return
+	  ;; a string or nil. I think is a non-desired behaviour from `org-element-parse-buffer'.
+	  (lambda (elt)
+	    "Return true if elements links which the text/label (third item) is not a string or nil."
+	    (not (or (null (caddr elt))
+		     (char-or-string-p (caddr elt)))))
+	  
+	  (delete-dups
+	   (org-element-map data 'link
+	     (lambda (link)
+	       (unless (member (org-element-property :type link) org-brain-ignored-resource-links)
+		 (cons (progn
+			 (goto-char (org-element-property :begin link))
+			 (ignore-errors (org-get-heading t t)))
+		       (list (org-element-property :raw-link link)
+			     (car (org-element-contents link))))))))
+
+		       ))))))))))
 
 (defun org-brain-insert-resource-button (resource &optional indent)
   "Insert a new line with a RESOURCE button, indented by INDENT spaces."

--- a/org-brain.el
+++ b/org-brain.el
@@ -579,7 +579,7 @@ If PROMPT is non nil, use `org-insert-link' even if not being run interactively.
   (let ((resources (org-brain-resources entry)))
     ;; Top level resources
     (when (mapc #'org-brain-insert-resource-button
-                (cl-remove-if (lambda (x) (eq nil (car x))) resources))
+                (cl-remove-if-not (lambda (x) (eq nil (car x))) resources))
       (insert "\n"))
     (org-element-map
         (with-temp-buffer
@@ -603,7 +603,7 @@ If PROMPT is non nil, use `org-insert-link' even if not being run interactively.
           (when (mapc (lambda (resource)
                         (org-brain-insert-resource-button
                          resource (1+ (org-element-property :level headline))))
-                      (cl-remove-if
+                      (cl-remove-if-not
                        (lambda (x) (string-equal head-title (car x))) resources))
             (insert "\n")))))))
 


### PR DESCRIPTION
While writing the issue #30 I tried to fix it: The `org-element-parse-buffer` doesn't return elements with texts as contents when a link of the format [[URL][URL]] (for example: `[[info:something#else%20new][info:something#else new]]`) is founded.

Thus, resources created by `org-brain-resources` need to filter this removing all resources in which its third element (I assume is the label or description) is not a string or nil.