### PR TITLE
Handle search for link in headline or in regular org brain visualize link

### DIFF
--- a/README.org
+++ b/README.org
@@ -32,8 +32,6 @@ Game Maker  Unity
 /* Gamasutra Articles
    - Passing Through Ghosts in Pac-Man
    - In-House Engine Development: Technical Tips
-
-/* Brainchildren
 #+END_EXAMPLE
 
 Above is a visualization of the /game programming/ entry (as can be seen in the
@@ -45,45 +43,70 @@ the entry: /Game Maker/ and /Unity/. At the very top you'll find pinned entries
 (entries which will be shown independent of the visualized entry).
 
 At the bottom the entry's table of contents (headlines in the buffer) is shown:
-/Gamasutra Articles/ and /Brainchildren/. You can also see the resources of the
-entry: the two Gamasutra articles and the Wikipedia link. Resources can be
-=org-mode= links in the entry file, or [[http://orgmode.org/manual/Attachments.html][org attachments]].
+/Gamasutra Articles/. You can also see the resources of the entry: the two
+Gamasutra articles and the Wikipedia link. Resources can be =org-mode= links in
+the entry file, or [[http://orgmode.org/manual/Attachments.html][org attachments]].
 
 The parents, children, siblings, headlines and resources are all links; they can
 be pressed to visualize other entries, visit resources etc.
+* Backwards compatability/breaking change: Version 0.4 changes the way child and parent relations are stored 
+Parent relationships for an entry are now stored as links under the
+=org-brain-parents-headline-default-name=, e.g., "Brainparents" by default,
+headline, whose creation and maintenance is automated by the =org-brain-visualize=
+interface commands.
 
+As before, child relationships for an entry are stored as links under the
+=org-brain-children-headline-default-name=, e.g., "Brainchildren by default,
+headline, whose creation and maintenance is automated by the =org-brain-visualize=
+interface commands.
+
+Ideally, you'll not manually operate on either the
+=org-brain-parents-headline-default-name= or the
+=org-brain-children-headline-default-name= headlines or their links. However, if
+you already have org-brain files in place and you do not wish to re-establish
+child and parent relationships through the =org-brain-visualize= interface for
+these existing files, then you may manually change the
+=org-brain-simple-link-type=, e.g., "brain:" by default, links under your
+=org-brain-children-headline-default-name=, e.g., "Brainchildren" by default,
+headline to be =org-brain-child-link-type=, e.g., "brainchild:" by default, links.
+
+Note that =org-brain-simple-link-type= links will continue to work as general
+links, similar to a "file:" link in Org, but they are not recognized by
+org-brain as child or parent relationship links. 
+
+This breaking change simplifies the logic of org-brain and greatly increases
+its performance.
 * Setup and requirements
-
 The easiest way is to get =org-brain= from MELPA. If you do not want to do that or
 would like this fork which includes caching and an extended visualize interface,
-here's the steps to install it manually:
+here are the steps to install it manually:
 
 1. =org-brain= requires Emacs 25, org-mode 9. These need to be part of your Emacs.
 2. Clone the repo locally (plug for [[https://github.com/motemen/ghq][ghq]] to manage local repo cloning).
 3. Utilize =use-package= to load the repo. (Alternatively, download =org-brain.el=, add it to your load-path, and put =(require 'org-brain)= in your init-file.)
-   #+begin_src emacs-lisp
+   #+begin_src emacs-lisp 
    (use-package org-brain
-     ;; :ensure t ; If you want to use MELPA package which doesn't include the caching and extended visualize interface.
+     ;; :ensure t ; If you want to use MELPA package.
      :load-path "~/.ghq/github.com/analyticd/org-brain"
      :init
-     (setq org-brain-path "/path/to/where/you/want/to/keep/your/org/brain/files/or/just/your/existing/org/files/directory"))
+     (setq org-brain-path "/path/to/where/you/want/to/keep/your/org/brain/files/or/just/your/existing/org-directory"))
    #+end_src
 4. Configure =org-brain-path= (defaults to =/brain= in your =org-directory=) to a directory where you want to put your =org-brain= files (which could be the location where you already keep your org files if you wish to transform your existing org files into =org-brain= files)
    You can set this with the example config presented above or through the customize interface,
 5. If you are an evil user, you'll want to add =(evil-set-initial-state 'org-brain-visualize-mode 'emacs)= to your =org-brain= configuration. Here is the config example above, updated:
    #+begin_src emacs-lisp
    (use-package org-brain
-     ;; :ensure t ; If you want to use MELPA package which doesn't include the caching and extended visualize interface.
+     ;; :ensure t ; If you want to use MELPA package.
      :load-path "~/.ghq/github.com/analyticd/org-brain"
      :init
-     (setq org-brain-path "/path/to/where/you/want/to/keep/your/org/brain/files/or/your/existing/org/files/directory")
+     (setq org-brain-path "/path/to/where/you/want/to/keep/your/org/brain/files/or/your/existing/org-directory")
      (eval-after-load 'evil
        (evil-set-initial-state 'org-brain-visualize-mode 'emacs)))
    #+end_src
 6. If you want to eagerly build some of the caches (rather than wait to have
    them built automatically in a lazy way), you may use =org-brain-build-caches=
    either interactively or programatically, perhaps during Emacs startup time
-   (while you get your coffee). You'll be adding about 15 seconds to Emacs
+   (while you get your coffee). You'll be adding about several seconds to Emacs
    startup time in exchange for the same savings of save on your initial use of
    org-brain. Example configuration for this:
    #+begin_src emacs-lisp
@@ -91,7 +114,7 @@ here's the steps to install it manually:
       ;; :ensure t ; Pull request not yet in MELPA package
       :load-path "~/.ghq/github.com/analyticd/org-brain"
       :init
-      (setq org-brain-path "/path/to/where/you/want/to/keep/your/org/brain/files/or/your/existing/org/files/directory")
+      (setq org-brain-path "/path/to/where/you/want/to/keep/your/org/brain/files/or/your/existing/org-directory")
       (eval-after-load 'evil
         (evil-set-initial-state 'org-brain-visualize-mode 'emacs))
       ;; Prebuild some of the org-brain caches during Emacs startup at the cost of
@@ -99,15 +122,12 @@ here's the steps to install it manually:
       (org-brain-build-caches))
    #+end_src
    Using =org-brain-build-caches= isn't necessary as, again, the caches are built
-   automatically in a lazy way during use of the org-brain-visualize interface.
-
+   automatically in a lazy way during use of the =org-brain-visualize= interface.
 * Usage
-
 Primarily you should interact with the =M-x org-brain-visualize= interface in
-order to benefit from automatic caching and thus dramatic speed gains (~30x
-faster).
+order to benefit from automatic caching and thus speed gains.
 
-Once in the org-brain-visualize interface/mode, via =M-x org-brain-visualize=, you can type:
+Once in the =org-brain-visualize= interface/mode, via =M-x org-brain-visualize=, you can type:
 
 1. "o" to open the current entry in your =org-brain= for editing.
 2. "c" to create a child for the current entry. You may enter several children at
@@ -163,17 +183,18 @@ Here is the the full list of keybindings:
 | f         | Find/visit another entry to visualize |
 | r         | Rename this, or another, entry        |
 
-In order to link to other entries, use an =org-mode= link
-with =brain:= type, its easiest to use =C-c C-l brain: TAB= or =M-x
-org-brain-insert-link=.
+In order to make simple, i.e., non-parent or child relationships in the
+org-brain sense, link to other entries, use an =org-mode= link with
+=org-brain-simple-link-type=, e.g., "brain:" by default type, its easiest to use
+=C-c C-l brain: TAB= or =M-x org-brain-insert-link=. There is no advantage
+currently, as of version 0.4 of org-brain to using an =org-brain-simple-link-type=
+over a regular org link. As noted earlier, =org-brain-visualize= commands manage
+child and parent relationships automatically.
 
 =M-x org-brain-agenda= can be used to run =org-agenda= on your =org-brain= files.
 
-If you add resources via =org-brain-visualize= they will be entered inserted under
-the current heading in the visualize buffer (link resource will be added as list
-items at the top of the heading in the entry file). If you're not under a
-heading in the visualize buffer, the resources will be added to /Brainchildren/,
-as in the case with adding new children.
+If you add resources via =org-brain-visualize= they will be inserted under
+the current heading in the visualize buffer. 
 
 Editing /Brainchildren/ manually is off the golden path. If you edit /Brainchildren/
 manually, i.e., outside the =org-brain-visualize= interface, then the caches will
@@ -185,44 +206,6 @@ to be built). =org-brain-files= cache is built all at once on first cache miss
 while =org-brain-children-cache=, =org-brain-parents-cache=, and
 =org-brain-pins-cache= are necessarily built node by node. Subsequent returns to
 said cached nodes will be approximately 30x faster.
-
-* A note about understanding the visualize interface (things to improve)
-:PROPERTIES:
-:ID:       0D41BB92-E21F-41EB-9310-FD5D54274626
-:END:
-A few things can still be improved which currently can be somewhat confusing:
-
-If there is a link /embedded/ in a headline title whose description is some subset
-of the headline title's text, then it will be shown as a
-child link of the headline one level higher and its description will be whatever
-said link's description was, as expected. E.g.,
-
-   * _This is a parent of the headline below_
-     - [[foo.txt][link]]  <-- the embedded link from the headline below is show here as a child in its normal org-mode link represetation, i.e., only link description showing
-   ** _This is an embedded [[file:foo.txt][link]] in a headline title_ <-- here the link will show in its expanded form as if in fundamental mode
-
-Note that the link on the level one headline targets the links path, as
-expected, and the embedded link in the level two headline targets the level two
-headline itself, as expected by the visualize interface.
-
-Now note that if you make the embedded link description equal to the whole
-headline title, e.g.,
-
-   * _This is a parent of the headline below_ <-- There is now no child link
-     - [[file:foo.txt][This is an embedded link in a headline title]] <-- This looks redundant with the headline below, but it points to the link location wherease the headline below points to the headline itself
-   ** _[[file:foo.txt][This is an embedded link in a headline title]]_ <-- Here the link will show in its expanded form as if in fundamental mode
-
-It will appear as a child link of the level one headline as before, but now it
-seems redundant, yet the link and headline have distinct targets.
-
-Here is another situation:
-
-If you have a link whose target path is an org-mode id and that org-mode id
-points to a headline, then it will be rendered as a link and a headline
-simultaneously, e.g.,
-
-    ***   - [[id:someheadlineid][someheadline]]
-
 * Other useful packages
 
 There's some missing functionality in =org-brain=, which could be useful,

--- a/README.org
+++ b/README.org
@@ -124,30 +124,36 @@ Once in the org-brain-visualize interface/mode, via =M-x org-brain-visualize=, y
    default name for these headlines, you can customize
    =org-brain-children-headline-default-name=.
 3. "C" to remove a child (link) for the current entry. This does not delete the
-   file pointed to by the child (link).
+   file pointed to by the child (link). You may enter several children at
+   once separated by =org-brain-batch-separator=, ";" by default, to
+   simultaneously remove more than one.
 4. "p" to create a parent for the current entry. You may enter several parents at
    once separated by =org-brain-batch-separator=, ";" by default, to
    simultaneously create more than one.
-5. "P" to pin the current entry (if it is already pinned, then =org-brain= will respect that)
-6. "R" to remove a pin from the current entry
-7. "r" to rename the current entry
+5. "P" to remove a parent for the current entry. You may enter several parents at
+   once separated by =org-brain-batch-separator=, ";" by default, to
+   simultaneously remove more than one.
+6. "n" to pin the current entry (if it is already pinned, then =org-brain= will respect that)
+7. "N" to remove a pin from the current entry
+8. "r" to rename the current entry
    This will only change the filename and entry name, not the =#+TITLE= of
    the entry.
-8. "t" to add or change the title of the current entry
+9. "t" to add or change the title of the current entry
    This will create a new title, prompting you for the value. If a
    title, #+TITLE: some-title, already exists then it will be replaced with the
    new title you've provide.
-9. "T" to remove a title of the current entry altogether.
+10. "T" to remove a title of the current entry altogether.
 
 Here is the the full list of keybindings:
 
 | j / TAB   | Goto next link                        |
 | k / S-TAB | Goto previous link                    |
-| c         | Add child                             |
-| C         | Remove child                          |
-| p         | Add parent                            |
-| P         | Add pin                               |
-| R         | Remove pin                            |
+| c         | Add child(ren)                        |
+| C         | Remove child(ren)                     |
+| p         | Add parent(s)                         |
+| P         | Remove parent(s)                      |
+| n         | Add pin                               |
+| N         | Remove pin                            |
 | t         | Add or change title                   |
 | T         | Remove title                          |
 | l         | Add resource link                     |

--- a/README.org
+++ b/README.org
@@ -69,7 +69,7 @@ here's the steps to install it manually:
      (setq org-brain-path "/path/to/where/you/want/to/keep/your/org/brain/files/or/just/your/existing/org/files/directory"))
    #+end_src
 4. Configure =org-brain-path= (defaults to =/brain= in your =org-directory=) to a directory where you want to put your =org-brain= files (which could be the location where you already keep your org files if you wish to transform your existing org files into =org-brain= files)
-   You can set this with the example config presented above or through the customize interface, 
+   You can set this with the example config presented above or through the customize interface,
 5. If you are an evil user, you'll want to add =(evil-set-initial-state 'org-brain-visualize-mode 'emacs)= to your =org-brain= configuration. Here is the config example above, updated:
    #+begin_src emacs-lisp
    (use-package org-brain
@@ -116,7 +116,7 @@ Once in the org-brain-visualize interface/mode, via =M-x org-brain-visualize=, y
    mandolin;banjo= would add =guitar=, =mandolin= and =banjo= as children. Currently
    it isn't possible to use completion when batch entering children/parents, so
    it is best used for adding non-existing entries.
-   
+
    If you add children to a file with =org-brain-visualize=, the links to the child
    entries will be added under the first headline in the file with the
    =brainchildren= tag. If this headline doesn't exist, a headline named
@@ -165,9 +165,9 @@ Here is the the full list of keybindings:
 
 In order to link to other entries, use an =org-mode= link
 with =brain:= type, its easiest to use =C-c C-l brain: TAB= or =M-x
-org-brain-insert-link=. 
+org-brain-insert-link=.
 
-=M-x org-brain-agenda= can be used to run =org-agenda= on your =org-brain= files. 
+=M-x org-brain-agenda= can be used to run =org-agenda= on your =org-brain= files.
 
 If you add resources via =org-brain-visualize= they will be entered inserted under
 the current heading in the visualize buffer (link resource will be added as list
@@ -185,6 +185,43 @@ to be built). =org-brain-files= cache is built all at once on first cache miss
 while =org-brain-children-cache=, =org-brain-parents-cache=, and
 =org-brain-pins-cache= are necessarily built node by node. Subsequent returns to
 said cached nodes will be approximately 30x faster.
+
+* A note about understanding the visualize interface (things to improve)
+:PROPERTIES:
+:ID:       0D41BB92-E21F-41EB-9310-FD5D54274626
+:END:
+A few things can still be improved which currently can be somewhat confusing:
+
+If there is a link /embedded/ in a headline title whose description is some subset
+of the headline title's text, then it will be shown as a
+child link of the headline one level higher and its description will be whatever
+said link's description was, as expected. E.g.,
+
+   * _This is a parent of the headline below_
+     - [[foo.txt][link]]  <-- the embedded link from the headline below is show here as a child in its normal org-mode link represetation, i.e., only link description showing
+   ** _This is an embedded [[file:foo.txt][link]] in a headline title_ <-- here the link will show in its expanded form as if in fundamental mode
+
+Note that the link on the level one headline targets the links path, as
+expected, and the embedded link in the level two headline targets the level two
+headline itself, as expected by the visualize interface.
+
+Now note that if you make the embedded link description equal to the whole
+headline title, e.g.,
+
+   * _This is a parent of the headline below_ <-- There is now no child link
+     - [[file:foo.txt][This is an embedded link in a headline title]] <-- This looks redundant with the headline below, but it points to the link location wherease the headline below points to the headline itself
+   ** _[[file:foo.txt][This is an embedded link in a headline title]]_ <-- Here the link will show in its expanded form as if in fundamental mode
+
+It will appear as a child link of the level one headline as before, but now it
+seems redundant, yet the link and headline have distinct targets.
+
+Here is another situation:
+
+If you have a link whose target path is an org-mode id and that org-mode id
+points to a headline, then it will be rendered as a link and a headline
+simultaneously, e.g.,
+
+    ***   - [[id:someheadlineid][someheadline]]
 
 * Other useful packages
 
@@ -231,15 +268,15 @@ You can add the function below to your init-file.
 org-board is a bookmarking and web archival system for Emacs Org mode, building on ideas from Pinboard. It archives your bookmarks so that you can access them even when you're not online, or when the site hosting them goes down.
 #+END_QUOTE
 ** [[https://github.com/gregdetre/emacs-freex][emacs-freex]]
-Emacs freex is a Pymacs/SQLite/Elisp system that implements a transcluding wiki.
-Emacs-freex is not compatible at this time with org-mode. Despite this,
-emacs-freex is an impressive system for maintaining a wiki. Further, because the
-data is stored both in files on disk and in an SQLite database, it opens the
-possibility for implementing something like =org-brain='s visualize interface (ala
-TheBrain's "plex") by talking with SQLite, via Pymacs, to return the
-relationships between nodes. This would consistute a lot of work to implement
-but would be very impressive. If someone was to also add LaTeX rendering inside
-=emacs-freex= =nuggets= also, those two additional features would make =emacs-freex=
-more compelling. As it is, practically speaking, you may think of =org-brain= as
-implementing many of the features of =emacs-freex=, but with all of =org-mode='s
-goodness included.
+Emacs freex is a Python/Sqlalchemy/Sqlite/Pymacs/Elisp system that implements a
+transcluding wiki. Emacs-freex is not compatible at this time with org-mode.
+Despite this, emacs-freex is an impressive system for maintaining a wiki.
+Further, because the data is stored both in files on disk and in an SQLite
+database, it opens the possibility for implementing something like =org-brain='s
+visualize interface (ala TheBrain's "plex") by talking with SQLite, via Pymacs,
+to return the relationships between nodes. This would consistute a lot of work
+to implement but would be very impressive. If someone was to also add LaTeX
+rendering inside =emacs-freex= =nuggets= also, those two additional features would
+make =emacs-freex= more compelling. As it is, practically speaking, you may think
+of =org-brain= as implementing many of the features of =emacs-freex=, but with all
+of =org-mode='s goodness included.

--- a/README.org
+++ b/README.org
@@ -127,25 +127,31 @@ can type:
    title, #+TITLE: some-title, already exists then it will be replaced with the
    new title you've provide.
 10. "T" to remove a title of the current entry altogether.
+11. "s" to do a completing read search of headlines in the current entry and
+    jump to selected headline in underlying file.
+12. "S" to do a completing read search of links in the current entry and jump to
+    selected link in underlying file.
 
 Here is the the full list of keybindings:
 
-| j / TAB   | Goto next link                        |
-| k / S-TAB | Goto previous link                    |
-| c         | Add child(ren)                        |
-| C         | Remove child(ren)                     |
-| p         | Add parent(s)                         |
-| P         | Remove parent(s)                      |
-| n         | Add pin                               |
-| N         | Remove pin                            |
-| t         | Add or change title                   |
-| T         | Remove title                          |
-| l         | Add resource link                     |
-| C-y       | Paste resource link                   |
-| a         | Add resource [[http://orgmode.org/manual/Attachments.html][attachment]]               |
-| o         | Open and edit the visualized entry    |
-| f         | Find/visit another entry to visualize |
-| r         | Rename this, or another, entry        |
+| j / TAB   | Goto next link                                                       |
+| k / S-TAB | Goto previous link                                                   |
+| c         | Add child(ren)                                                       |
+| C         | Remove child(ren)                                                    |
+| p         | Add parent(s)                                                        |
+| P         | Remove parent(s)                                                     |
+| n         | Add pin                                                              |
+| N         | Remove pin                                                           |
+| t         | Add or change title                                                  |
+| T         | Remove title                                                         |
+| l         | Add resource link                                                    |
+| C-y       | Paste resource link                                                  |
+| a         | Add resource [[http://orgmode.org/manual/Attachments.html][attachment]]                                              |
+| o         | Open and edit the visualized entry                                   |
+| f         | Find/visit another entry to visualize                                |
+| r         | Rename this, or another, entry                                       |
+| s         | Search for headline in current entry and jump to selected headline in underlying file |
+| S         | Search for link in current entry and jump to selected link in underlying file |
 
 In order to make a link to another org-brain entries, use an =org-mode= link with
 =org-brain-link-type= type, e.g., "brain:" by default. Its easiest to use

--- a/README.org
+++ b/README.org
@@ -103,7 +103,9 @@ here's the steps to install it manually:
 
 * Usage
 
-Primarily you should interact with the =M-x org-brain-visualize= interface in order to benefit from automatic caching and thus dramatic speed gains (~30x faster).
+Primarily you should interact with the =M-x org-brain-visualize= interface in
+order to benefit from automatic caching and thus dramatic speed gains (~30x
+faster).
 
 Once in the org-brain-visualize interface/mode, via =M-x org-brain-visualize=, you can type:
 

--- a/README.org
+++ b/README.org
@@ -125,12 +125,13 @@ Once in the org-brain-visualize interface/mode, via =M-x org-brain-visualize=, y
    once separated by =org-brain-batch-separator=, ";" by default, to
    simultaneously create more than one.
 4. "P" to pin the current entry (if it is already pinned, then =org-brain= will respect that)
-5. "r" to rename the current entry
+5. "R" to remove a pin from the current entry
+6. "r" to rename the current entry
    This will only change the filename and entry name, not the =#+TITLE= of
    the entry.
-6. "t" to add or change the title of the current entry
+7. "t" to add or change the title of the current entry
    This will create a new title, prompting you for the value. If a
-   title, #+TITLE: some-title, already exists then it will replace it with the
+   title, #+TITLE: some-title, already exists then it will be replaced with the
    new title you've provide.
 
 Here is the the full list of keybindings:
@@ -140,6 +141,7 @@ Here is the the full list of keybindings:
 | c         | Add child                             |
 | p         | Add parent                            |
 | P         | Add pin                               |
+| R         | Remove pin                            |
 | t         | Add or change title                   |
 | l         | Add resource link                     |
 | C-y       | Paste resource link                   |

--- a/README.org
+++ b/README.org
@@ -80,6 +80,26 @@ here's the steps to install it manually:
      (eval-after-load 'evil
        (evil-set-initial-state 'org-brain-visualize-mode 'emacs)))
    #+end_src
+6. If you want to eagerly build some of the caches (rather than wait to have
+   them built automatically in a lazy way), you may use =org-brain-build-caches=
+   either interactively or programatically, perhaps during Emacs startup time
+   (while you get your coffee). You'll be adding about 15 seconds to Emacs
+   startup time in exchange for the same savings of save on your initial use of
+   org-brain. Example configuration for this:
+   #+begin_src emacs-lisp
+    (use-package org-brain
+      ;; :ensure t ; Pull request not yet in MELPA package
+      :load-path "~/.ghq/github.com/analyticd/org-brain"
+      :init
+      (setq org-brain-path "/path/to/where/you/want/to/keep/your/org/brain/files/or/your/existing/org/files/directory")
+      (eval-after-load 'evil
+        (evil-set-initial-state 'org-brain-visualize-mode 'emacs))
+      ;; Prebuild some of the org-brain caches during Emacs startup at the cost of
+      ;; slower Emacs startup time.
+      (org-brain-build-caches))
+   #+end_src
+   Using =org-brain-build-caches= isn't necessary as, again, the caches are built
+   automatically in a lazy way during use of the org-brain-visualize interface.
 
 * Usage
 

--- a/README.org
+++ b/README.org
@@ -156,7 +156,6 @@ org-brain-insert-link=.
 
 =M-x org-brain-agenda= can be used to run =org-agenda= on your =org-brain= files. 
 
-
 If you add resources via =org-brain-visualize= they will be entered inserted under
 the current heading in the visualize buffer (link resource will be added as list
 items at the top of the heading in the entry file). If you're not under a
@@ -170,8 +169,8 @@ be inconsistent with actual state on disk. To remedy this situation, you may use
 caches will be rebuilt and speed of the org-brain-visualize interface/mode will
 become very fast again after an initial cache miss (which will cause the caches
 to be built). =org-brain-files= cache is built all at once on first cache miss
-while org-brain-children-cache, org-brain-parents-cache, and
-org-brain-pins-cache are necessarily built node by node. Subsequent returns to
+while =org-brain-children-cache=, =org-brain-parents-cache=, and
+=org-brain-pins-cache= are necessarily built node by node. Subsequent returns to
 said cached nodes will be approximately 30x faster.
 
 * Other useful packages

--- a/README.org
+++ b/README.org
@@ -47,35 +47,24 @@ At the bottom the entry's table of contents (headlines in the buffer) is shown:
 Gamasutra articles and the Wikipedia link. Resources can be =org-mode= links in
 the entry file, or [[http://orgmode.org/manual/Attachments.html][org attachments]].
 
-The parents, children, siblings, headlines and resources are all links; they can
+The parents, children, siblings, headlines, and resources are all links; they can
 be pressed to visualize other entries, visit resources etc.
-* Backwards compatability/breaking change: Version 0.4 changes the way child and parent relations are stored 
-Parent relationships for an entry are now stored as links under the
-=org-brain-parents-headline-default-name=, e.g., "Brainparents" by default,
-headline, whose creation and maintenance is automated by the =org-brain-visualize=
-interface commands.
+* Backwards compatability/breaking change: Version 0.5 changes the way child and parent relations, and pins, are stored 
+Parent and child relationships are serialized to disk in sexp form. Same with
+pinned entries. Their creation and maintenance is managed by =org-brain-visualize=
+mode commands. Therefore, the "Brainchildren" headline is no longer used in
+org-brain files by =org-brain= and is therefore deprecated as of this release.
+Note also that #+BRAIN_PIN: is no longer used either and is also deprecated as
+of this release.
 
-As before, child relationships for an entry are stored as links under the
-=org-brain-children-headline-default-name=, e.g., "Brainchildren by default,
-headline, whose creation and maintenance is automated by the =org-brain-visualize=
-interface commands.
+Note that =org-brain-link-type= links will continue to work as general links,
+similar to a "file:" link in Org, but they are not recognized by =org-brain= as
+child or parent relationship links. 
 
-Ideally, you'll not manually operate on either the
-=org-brain-parents-headline-default-name= or the
-=org-brain-children-headline-default-name= headlines or their links. However, if
-you already have org-brain files in place and you do not wish to re-establish
-child and parent relationships through the =org-brain-visualize= interface for
-these existing files, then you may manually change the
-=org-brain-simple-link-type=, e.g., "brain:" by default, links under your
-=org-brain-children-headline-default-name=, e.g., "Brainchildren" by default,
-headline to be =org-brain-child-link-type=, e.g., "brainchild:" by default, links.
-
-Note that =org-brain-simple-link-type= links will continue to work as general
-links, similar to a "file:" link in Org, but they are not recognized by
-org-brain as child or parent relationship links. 
-
-This breaking change simplifies the logic of org-brain and greatly increases
-its performance.
+This release's changes simplify the logic of org-brain, greatly increase its
+performance, and most importantly, keeps all meta-data needed by org-brain out
+of your org brain files (with the exception of #+TITLE: which is a standard
+=org-mode= concept.
 * Setup and requirements
 The easiest way is to get =org-brain= from MELPA. If you do not want to do that or
 would like this fork which includes caching and an extended visualize interface,
@@ -101,33 +90,15 @@ here are the steps to install it manually:
      :init
      (setq org-brain-path "/path/to/where/you/want/to/keep/your/org/brain/files/or/your/existing/org-directory")
      (eval-after-load 'evil
-       (evil-set-initial-state 'org-brain-visualize-mode 'emacs)))
+       (evil-set-initial-state 'org-brain-visualize-mode 'emacs))
+     :config
+     (bind-key [(meta f9)] #'org-brain-visualize)) ; Handy keybinding, use whatever binding you want
    #+end_src
-6. If you want to eagerly build some of the caches (rather than wait to have
-   them built automatically in a lazy way), you may use =org-brain-build-caches=
-   either interactively or programatically, perhaps during Emacs startup time
-   (while you get your coffee). You'll be adding about several seconds to Emacs
-   startup time in exchange for the same savings of save on your initial use of
-   org-brain. Example configuration for this:
-   #+begin_src emacs-lisp
-    (use-package org-brain
-      ;; :ensure t ; Pull request not yet in MELPA package
-      :load-path "~/.ghq/github.com/analyticd/org-brain"
-      :init
-      (setq org-brain-path "/path/to/where/you/want/to/keep/your/org/brain/files/or/your/existing/org-directory")
-      (eval-after-load 'evil
-        (evil-set-initial-state 'org-brain-visualize-mode 'emacs))
-      ;; Prebuild some of the org-brain caches during Emacs startup at the cost of
-      ;; slower Emacs startup time.
-      (org-brain-build-caches))
-   #+end_src
-   Using =org-brain-build-caches= isn't necessary as, again, the caches are built
-   automatically in a lazy way during use of the =org-brain-visualize= interface.
 * Usage
-Primarily you should interact with the =M-x org-brain-visualize= interface in
-order to benefit from automatic caching and thus speed gains.
+You interact with =org-brain= via the =M-x org-brain-visualize= interface.
 
-Once in the =org-brain-visualize= interface/mode, via =M-x org-brain-visualize=, you can type:
+Once in the =org-brain-visualize= interface/mode, via =M-x org-brain-visualize=, you
+can type:
 
 1. "o" to open the current entry in your =org-brain= for editing.
 2. "c" to create a child for the current entry. You may enter several children at
@@ -136,13 +107,6 @@ Once in the =org-brain-visualize= interface/mode, via =M-x org-brain-visualize=,
    mandolin;banjo= would add =guitar=, =mandolin= and =banjo= as children. Currently
    it isn't possible to use completion when batch entering children/parents, so
    it is best used for adding non-existing entries.
-
-   If you add children to a file with =org-brain-visualize=, the links to the child
-   entries will be added under the first headline in the file with the
-   =brainchildren= tag. If this headline doesn't exist, a headline named
-   /Brainchildren/ will be created and will be given the tag. If you want another
-   default name for these headlines, you can customize
-   =org-brain-children-headline-default-name=.
 3. "C" to remove a child (link) for the current entry. This does not delete the
    file pointed to by the child (link). You may enter several children at
    once separated by =org-brain-batch-separator=, ";" by default, to
@@ -183,29 +147,19 @@ Here is the the full list of keybindings:
 | f         | Find/visit another entry to visualize |
 | r         | Rename this, or another, entry        |
 
-In order to make simple, i.e., non-parent or child relationships in the
-org-brain sense, link to other entries, use an =org-mode= link with
-=org-brain-simple-link-type=, e.g., "brain:" by default type, its easiest to use
-=C-c C-l brain: TAB= or =M-x org-brain-insert-link=. There is no advantage
-currently, as of version 0.4 of org-brain to using an =org-brain-simple-link-type=
-over a regular org link. As noted earlier, =org-brain-visualize= commands manage
-child and parent relationships automatically.
+In order to make a link to another org-brain entries, use an =org-mode= link with
+=org-brain-link-type= type, e.g., "brain:" by default. Its easiest to use
+=C-c C-l br TAB= and select the "brain:" type, or =M-x org-brain-insert-link=.
+=org-brain-link-type= has the advantage that it provides completion on your
+=org-brain-files=. Note, however, that as of version 0.5 of =org-brain=,
+=org-brain-link-type= links do not play a part in defining child or parent
+relationships. They are now simply links, analogous to regular org-mode links to
+other resources.
 
 =M-x org-brain-agenda= can be used to run =org-agenda= on your =org-brain= files.
 
 If you add resources via =org-brain-visualize= they will be inserted under
 the current heading in the visualize buffer. 
-
-Editing /Brainchildren/ manually is off the golden path. If you edit /Brainchildren/
-manually, i.e., outside the =org-brain-visualize= interface, then the caches will
-be inconsistent with actual state on disk. To remedy this situation, you may use
-=M-x org-brain-invalidate-all-caches= after making such edits. Subsequently the
-caches will be rebuilt and speed of the org-brain-visualize interface/mode will
-become very fast again after an initial cache miss (which will cause the caches
-to be built). =org-brain-files= cache is built all at once on first cache miss
-while =org-brain-children-cache=, =org-brain-parents-cache=, and
-=org-brain-pins-cache= are necessarily built node by node. Subsequent returns to
-said cached nodes will be approximately 30x faster.
 * Other useful packages
 
 There's some missing functionality in =org-brain=, which could be useful,

--- a/README.org
+++ b/README.org
@@ -135,6 +135,7 @@ Once in the org-brain-visualize interface/mode, via =M-x org-brain-visualize=, y
    This will create a new title, prompting you for the value. If a
    title, #+TITLE: some-title, already exists then it will be replaced with the
    new title you've provide.
+8. "T" to remove a title of the current entry altogether.
 
 Here is the the full list of keybindings:
 
@@ -145,6 +146,7 @@ Here is the the full list of keybindings:
 | P         | Add pin                               |
 | R         | Remove pin                            |
 | t         | Add or change title                   |
+| T         | Remove title                          |
 | l         | Add resource link                     |
 | C-y       | Paste resource link                   |
 | a         | Add resource [[http://orgmode.org/manual/Attachments.html][attachment]]               |

--- a/README.org
+++ b/README.org
@@ -123,25 +123,28 @@ Once in the org-brain-visualize interface/mode, via =M-x org-brain-visualize=, y
    /Brainchildren/ will be created and will be given the tag. If you want another
    default name for these headlines, you can customize
    =org-brain-children-headline-default-name=.
-3. "p" to create a parent for the current entry. You may enter several parents at
+3. "C" to remove a child (link) for the current entry. This does not delete the
+   file pointed to by the child (link).
+4. "p" to create a parent for the current entry. You may enter several parents at
    once separated by =org-brain-batch-separator=, ";" by default, to
    simultaneously create more than one.
-4. "P" to pin the current entry (if it is already pinned, then =org-brain= will respect that)
-5. "R" to remove a pin from the current entry
-6. "r" to rename the current entry
+5. "P" to pin the current entry (if it is already pinned, then =org-brain= will respect that)
+6. "R" to remove a pin from the current entry
+7. "r" to rename the current entry
    This will only change the filename and entry name, not the =#+TITLE= of
    the entry.
-7. "t" to add or change the title of the current entry
+8. "t" to add or change the title of the current entry
    This will create a new title, prompting you for the value. If a
    title, #+TITLE: some-title, already exists then it will be replaced with the
    new title you've provide.
-8. "T" to remove a title of the current entry altogether.
+9. "T" to remove a title of the current entry altogether.
 
 Here is the the full list of keybindings:
 
 | j / TAB   | Goto next link                        |
 | k / S-TAB | Goto previous link                    |
 | c         | Add child                             |
+| C         | Remove child                          |
 | p         | Add parent                            |
 | P         | Add pin                               |
 | R         | Remove pin                            |

--- a/org-brain.el
+++ b/org-brain.el
@@ -698,7 +698,7 @@ PARENT can hold multiple entries, by using `org-brain-batch-separator'."
     (with-current-buffer (find-file-noselect entry-path)
       (when (not (assoc "BRAIN_PIN" (org-brain-keywords entry)))
         (goto-char (point-min))
-        (insert "\n#+BRAIN_PIN:\n")
+        (insert "#+BRAIN_PIN:\n")
         (save-buffer)))))
 
 (defun org-brain-visualize-remove-pin ()
@@ -742,7 +742,7 @@ PARENT can hold multiple entries, by using `org-brain-batch-separator'."
       (if (not (assoc "TITLE" (org-brain-keywords entry)))
           (progn
             (goto-char (point-min))
-            (insert (format "\n#+TITLE: %s\n" title))
+            (insert (format "#+TITLE: %s\n" title))
             (save-buffer))
         ;; Remove #+TITLE: ... and create new one
         (progn
@@ -752,7 +752,7 @@ PARENT can hold multiple entries, by using `org-brain-batch-separator'."
           (when (looking-at "^#\\+TITLE: +.*$")
             (kill-line)
             (goto-char (point-min))
-            (insert (format "\n#+TITLE: %s\n" title))
+            (insert (format "#+TITLE: %s\n" title))
             (save-buffer)))))))
 
 (define-derived-mode org-brain-visualize-mode

--- a/org-brain.el
+++ b/org-brain.el
@@ -75,7 +75,7 @@ This will be used by `org-brain-new-child'."
           (t (setf node (cdr node))))))
 
 ;;; Logging
-(defcustom org-brain-log t
+(defcustom org-brain-log nil
   "Set to nil to not write to *Messages* buffer."
   :group 'org-brain
   :type 'boolean)

--- a/org-brain.el
+++ b/org-brain.el
@@ -369,7 +369,7 @@ NEWENTRY. The ENTRY file will also be renamed."
          (read-string "New name: ")))
   (let ((oldfile (org-brain-entry-path entry))
         (newfile (org-brain-entry-path newname)))
-    (org-brain-invalidate-files-cache)    ; NOTE Invalidate org-brain file cache
+    (org-brain-invalidate-files-cache)  ; Invalidate cache
     (mapc
      (lambda (brainfile)
        (with-temp-buffer

--- a/org-brain.el
+++ b/org-brain.el
@@ -336,17 +336,14 @@ You can choose to EXCLUDE an entry from the list."
           (save-excursion
             (re-search-forward
              (format "^\\*.*:%s:.*$" org-brain-children-tag-default-name) nil t)
-            (let ((bound (outline-next-heading)))
-              (re-search-backward
-               (format "^\\*.*:%s:.*$" org-brain-children-tag-default-name) nil t)
-              (beginning-of-line)
-              (re-search-forward
-               (format "^ *- \\[\\[brain:%s.*$" child-to-remove) bound t)
-              (beginning-of-line)
-              (looking-at (format "^ *- \\[\\[brain:%s.*$" child-to-remove))
-              (kill-line 1)
-              (save-buffer)
-              (org-brain-invalidate-child-cache-entry entry)))))))
+            (beginning-of-line)
+            (re-search-forward
+             (format "^ *- \\[\\[brain:%s.*$" child-to-remove) nil t)
+            (beginning-of-line)
+            (looking-at (format "^ *- \\[\\[brain:%s.*$" child-to-remove))
+            (kill-line 1)
+            (save-buffer)
+            (org-brain-invalidate-child-cache-entry entry))))))
 
 (defun org-brain-insert-visualize-button (entry)
   "Insert a button, which runs `org-brain-visualize' on ENTRY when clicked."

--- a/org-brain.el
+++ b/org-brain.el
@@ -99,10 +99,10 @@ This will be used by `org-brain-new-child'."
     (setq inhibit-message nil)))
 
 ;;; Caches
-(setq org-brain-files-cache nil)
-(setq org-brain-parents-cache nil)
-(setq org-brain-children-cache nil)
-(setq org-brain-pins-cache nil)
+(defvar org-brain-files-cache nil "Cache for org-brain-files")
+(defvar org-brain-parents-cache nil "Cache for org-brain-parents")
+(defvar org-brain-children-cache nil "Cache for org-brain-children")
+(defvar org-brain-pins-cache nil "Cache for org-brain-pins")
 
 ;;;###autoload
 (defun org-brain-invalidate-all-caches ()

--- a/org-brain.el
+++ b/org-brain.el
@@ -528,6 +528,131 @@ If PROMPT is non nil, use `org-insert-link' even if not being run interactively.
         (goto-char position)))))
 
 
+(defun org-brain--insert-headlines-and-resources (entry)
+  "Insert a horizontal separator followed by the headlines and
+  resources for the ENTRY in the visualize interface."
+  (insert "\n\n-----------------------------------------------\n\n")
+  (let ((resources (org-brain-resources entry)))
+    ;; Top level resources
+    (when (mapc #'org-brain-insert-resource-button
+                (cl-remove-if (lambda (x) (eq nil (car x))) resources))
+      (insert "\n"))
+    (org-element-map
+        (with-temp-buffer
+          (ignore-errors (insert-file-contents (org-brain-entry-path entry)))
+          (delay-mode-hooks
+            (org-mode)
+            (org-element-parse-buffer)))
+        'headline
+      (lambda (headline)
+        (let ((head-title (org-element-property :raw-value headline)))
+          (insert (make-string (org-element-property :level headline) ?*) " ")
+          (insert-text-button
+           head-title
+           'action (lambda (_x)
+                     (org-open-file (org-brain-entry-path entry)
+                                    nil nil
+                                    (concat "*" head-title)))
+           'follow-link t)
+          (insert "\n")
+          ;; Headline resources
+          (when (mapc (lambda (resource)
+                        (org-brain-insert-resource-button
+                         resource (1+ (org-element-property :level headline))))
+                      (cl-remove-if
+                       (lambda (x) (string-equal head-title (car x))) resources))
+            (insert "\n")))))))
+
+(defun org-brain--insert-pinned-entries ()
+  "Insert the pinned entries in the visualize interface."
+  (insert "PINNED:")
+  (mapc (lambda (pin)
+          (insert "  ")
+          (org-brain-insert-visualize-button pin))
+        (org-brain-pins))
+  (insert "\n\n\n"))
+
+(defun org-brain--insert-parent-and-sibling-entries (entry &optional ignored-siblings)
+  "Insert parent and sibling entries into the visualize
+  interface."
+  (let ((parent-positions nil)
+        (max-width 0))
+    (mapc (lambda (parent)
+            (push parent ignored-siblings)
+            (let ((children-links (set-difference
+                                   (org-brain-children parent entry)
+                                   ignored-siblings))
+                  (col-start (+ 3 max-width))
+                  (parent-title (org-brain-title parent)))
+              (goto-line 4)
+              (mapc
+               (lambda (child)
+                 (picture-forward-column col-start)
+                 (insert (make-string (1+ (length parent-title)) ?\ ) "/ ")
+                 (org-brain-insert-visualize-button child)
+                 (setq max-width (max max-width (current-column)))
+                 (newline (forward-line 1))
+                 (push child ignored-siblings))
+               children-links)
+              (goto-line 4)
+              (forward-line (1- (length children-links)))
+              (picture-forward-column col-start)
+              (push (cons (picture-current-line)
+                          (+ (current-column) (/ (length parent-title) 2)))
+                    parent-positions)
+              (org-brain-insert-visualize-button parent)
+              (setq max-width (max max-width (current-column)))
+              (when children-links
+                (delete-char (length parent-title)))))
+          (org-brain-parents entry))
+    ;; Draw lines
+    (when parent-positions
+      (let ((maxline (line-number-at-pos (point-max))))
+        ;; Bottom line
+        (goto-line maxline)
+        (picture-forward-column (cdar (last parent-positions)))
+        (picture-move-down 1)
+        (insert (make-string (1+ (- (cdar parent-positions)
+                                    (cdar (last parent-positions))))
+                             ?-))
+        ;; Lines from parents to bottom
+        (mapc (lambda (pos)
+                (goto-line (car pos))
+                (picture-forward-column (cdr pos))
+                (while (< (line-number-at-pos (point))
+                          maxline)
+                  (picture-move-down 1)
+                  (insert "|")
+                  (unless (looking-at-p "\n") (delete-char 1)))
+                (picture-move-down 1)
+                (ignore-errors
+                  (delete-char 1))
+                (insert "*"))
+              parent-positions)
+        ;; Line to main entry
+        (move-to-column (/ (+ (cdar (last parent-positions))
+                              (cdar parent-positions))
+                           2))
+        (delete-char 1)
+        (when (> (length parent-positions) 1)
+          (insert "*")
+          (backward-char 1)
+          (picture-move-down 1)
+          (insert "|")
+          (picture-move-down 1))
+        (insert "V")))))
+
+(defun org-brain--insert-entry-children (entry)
+  "Insert ENTRY children into the visualize interface."
+  (mapc (lambda (child)
+          (let ((child-title (org-brain-title child)))
+            (when (> (+ (current-column) (length child-title))
+                     fill-column)
+              (insert "\n"))
+            (org-brain-insert-visualize-button child)
+            (insert "  ")))
+        (org-brain-children entry)))
+
 ;;;###autoload
 (defun org-brain-visualize (entry &optional ignored-siblings nofocus)
   "View a concept map with ENTRY at the center.
@@ -545,79 +670,9 @@ the concept map buffer will gain focus."
     (read-only-mode -1)
     (delete-region (point-min) (point-max))
     ;; Pinned entries
-    (insert "PINNED:")
-    (mapc (lambda (pin)
-            (insert "  ")
-            (org-brain-insert-visualize-button pin))
-          (org-brain-pins))
-    (insert "\n\n\n")
+    (org-brain--insert-pinned-entries)
     ;; Draw parent entries and siblings
-    (let ((parent-positions nil)
-          (max-width 0))
-      (mapc (lambda (parent)
-              (push parent ignored-siblings)
-              (let ((children-links (set-difference
-                                     (org-brain-children parent entry)
-                                                 ignored-siblings))
-                    (col-start (+ 3 max-width))
-                    (parent-title (org-brain-title parent)))
-                (goto-line 4)
-                (mapc
-                 (lambda (child)
-                   (picture-forward-column col-start)
-                   (insert (make-string (1+ (length parent-title)) ?\ ) "/ ")
-                   (org-brain-insert-visualize-button child)
-                   (setq max-width (max max-width (current-column)))
-                   (newline (forward-line 1))
-                   (push child ignored-siblings))
-                 children-links)
-                (goto-line 4)
-                (forward-line (1- (length children-links)))
-                (picture-forward-column col-start)
-                (push (cons (picture-current-line)
-                            (+ (current-column) (/ (length parent-title) 2)))
-                      parent-positions)
-                (org-brain-insert-visualize-button parent)
-                (setq max-width (max max-width (current-column)))
-                (when children-links
-                  (delete-char (length parent-title)))))
-            (org-brain-parents entry))
-      ;; Draw lines
-      (when parent-positions
-        (let ((maxline (line-number-at-pos (point-max))))
-          ;; Bottom line
-          (goto-line maxline)
-          (picture-forward-column (cdar (last parent-positions)))
-          (picture-move-down 1)
-          (insert (make-string (1+ (- (cdar parent-positions)
-                                      (cdar (last parent-positions))))
-                               ?-))
-          ;; Lines from parents to bottom
-          (mapc (lambda (pos)
-                  (goto-line (car pos))
-                  (picture-forward-column (cdr pos))
-                  (while (< (line-number-at-pos (point))
-                            maxline)
-                    (picture-move-down 1)
-                    (insert "|")
-                    (unless (looking-at-p "\n") (delete-char 1)))
-                  (picture-move-down 1)
-                  (ignore-errors
-                    (delete-char 1))
-                  (insert "*"))
-                parent-positions)
-          ;; Line to main entry
-          (move-to-column (/ (+ (cdar (last parent-positions))
-                                (cdar parent-positions))
-                             2))
-          (delete-char 1)
-          (when (> (length parent-positions) 1)
-            (insert "*")
-            (backward-char 1)
-            (picture-move-down 1)
-            (insert "|")
-            (picture-move-down 1))
-          (insert "V"))))
+    (org-brain--insert-parent-and-sibling-entries entry ignored-siblings)
     ;; Insert main entry name
     (picture-move-down 1)
     (let ((half-title-length (/ (length (org-brain-title entry)) 2)))
@@ -628,45 +683,9 @@ the concept map buffer will gain focus."
     (let ((entry-pos (point)))
       (insert (org-brain-title entry) "\n\n")
       ;; Insert entry children
-      (mapc (lambda (child)
-              (let ((child-title (org-brain-title child)))
-                (when (> (+ (current-column) (length child-title))
-                         fill-column)
-                  (insert "\n"))
-                (org-brain-insert-visualize-button child)
-                (insert "  ")))
-            (org-brain-children entry))
+      (org-brain--insert-entry-children entry)
       ;; Insert headlines and resources in entry file
-      (insert "\n\n-----------------------------------------------\n\n")
-      (let ((resources (org-brain-resources entry)))
-        ;; Top level resources
-        (when (mapc #'org-brain-insert-resource-button
-                    (cl-remove-if (lambda (x) (eq nil (car x))) resources))
-          (insert "\n"))
-        (org-element-map (with-temp-buffer
-                           (ignore-errors (insert-file-contents (org-brain-entry-path entry)))
-                           (delay-mode-hooks
-                             (org-mode)
-                             (org-element-parse-buffer)))
-            'headline
-          (lambda (headline)
-            (let ((head-title (org-element-property :raw-value headline)))
-              (insert (make-string (org-element-property :level headline) ?*) " ")
-              (insert-text-button
-               head-title
-               'action (lambda (_x)
-                         (org-open-file (org-brain-entry-path entry)
-                                        nil nil
-                                        (concat "*" head-title)))
-               'follow-link t)
-              (insert "\n")
-              ;; Headline resources
-              (when (mapc (lambda (resource)
-                            (org-brain-insert-resource-button
-                             resource (1+ (org-element-property :level headline))))
-                          (cl-remove-if
-                           (lambda (x) (string-equal head-title (car x))) resources))
-                (insert "\n"))))))
+      (org-brain--insert-headlines-and-resources entry)
       ;; Finishing
       (org-brain-visualize-mode)
       (goto-char entry-pos)

--- a/org-brain.el
+++ b/org-brain.el
@@ -123,6 +123,17 @@ This will be used by `org-brain-new-child'."
   (org-brain-log "Invalidating org-brain pin cache...")
   (setq org-brain-pins-cache nil))
 
+(defun org-brain-build-caches ()
+  "(Optional) It is not necessary to use this function as the
+  caches are built lazily, automatically. However, this is just
+  here if you want to do some cache building ahead of time, for
+  instance during Emacs startup (at the cost of a longer Emacs
+  startup) while you grab your coffee."
+  (interactive)
+  (org-brain-log "Eagerly building some of the org-brain caches..")
+  (org-brain-files)
+  (org-brain-pins))
+
 (defun org-brain-files (&optional relative)
   "Get all org files (recursively) in `org-brain-path'.
 If RELATIVE is t, then return relative paths and remove org extension."

--- a/org-brain.el
+++ b/org-brain.el
@@ -664,7 +664,8 @@ CHILD can hold multiple entries, by using `org-brain-batch-separator'."
   (interactive
    (list (completing-read "Child: " (org-brain-files t))))
   (org-brain-invalidate-files-cache)    ; Invalidate cache
-  (org-brain-invalidate-child-cache-entry org-brain--visualizing-entry) ; Invalidate cache
+  (org-brain-invalidate-child-cache-entry
+   org-brain--visualizing-entry)        ; Invalidate cache
   (dolist (c (split-string child org-brain-batch-separator t " +"))
     (org-brain-new-child org-brain--visualizing-entry c))
   (when (string-equal (buffer-name) "*org-brain*")
@@ -676,7 +677,8 @@ PARENT can hold multiple entries, by using `org-brain-batch-separator'."
   (interactive
    (list (completing-read "Parent: " (org-brain-files t))))
   (org-brain-invalidate-files-cache)    ; Invalidate cache
-  (org-brain-invalidate-parent-cache-entry org-brain--visualizing-entry) ; Invalidate cache
+  (org-brain-invalidate-parent-cache-entry
+   org-brain--visualizing-entry)        ; Invalidate cache
   (dolist (p (split-string parent org-brain-batch-separator t " +"))
     (org-brain-new-child p org-brain--visualizing-entry))
   (when (string-equal (buffer-name) "*org-brain*")

--- a/org-brain.el
+++ b/org-brain.el
@@ -189,27 +189,26 @@ If RELATIVE is t, then return relative paths and remove org extension."
   (if (and org-brain-parents-cache
            (assoc entry org-brain-parents-cache))
       (cdr (assoc entry org-brain-parents-cache))
-    (progn
-      (org-brain-log (format  "Updating org-brain-parents-cache for %s..." entry))
-      (let ((parents (remove nil
-                      (mapcar
-                       (lambda (brainfile)
-                         (let ((brainfile-entry (org-brain-path-entry-name brainfile)))
-                           (unless (string-equal brainfile-entry entry)
-                             (org-element-map
-                                 (with-temp-buffer
-                                   (insert-file-contents brainfile)
-                                   (org-element-parse-buffer))
-                                 'link
-                               (lambda (link)
-                                 (when (and (string-equal (org-element-property :type link) "brain")
-                                            (string-equal (car (split-string (org-element-property :path link) "::"))
-                                                          entry))
-                                   brainfile-entry))
-                               nil t))))
-                       (org-brain-files)))))
-        (push (cons entry . (parents)) org-brain-parents-cache)
-        (cdr (assoc entry org-brain-parents-cache))))))
+    (org-brain-log (format  "Updating org-brain-parents-cache for %s..." entry))
+    (let ((parents (remove nil
+                           (mapcar
+                            (lambda (brainfile)
+                              (let ((brainfile-entry (org-brain-path-entry-name brainfile)))
+                                (unless (string-equal brainfile-entry entry)
+                                  (org-element-map
+                                      (with-temp-buffer
+                                        (insert-file-contents brainfile)
+                                        (org-element-parse-buffer))
+                                      'link
+                                    (lambda (link)
+                                      (when (and (string-equal (org-element-property :type link) "brain")
+                                                 (string-equal (car (split-string (org-element-property :path link) "::"))
+                                                               entry))
+                                        brainfile-entry))
+                                    nil t))))
+                            (org-brain-files)))))
+      (push (cons entry . (parents)) org-brain-parents-cache)
+      (cdr (assoc entry org-brain-parents-cache)))))
 
 (defun org-brain-children (entry &optional exclude)
   "Get list of org-brain entries linked to from ENTRY.

--- a/org-brain.el
+++ b/org-brain.el
@@ -811,23 +811,21 @@ If PROMPT is non nil, use `org-insert-link' even if not being run interactively.
              (description (org-brain--link-description
                            (list raw-link
                                  link-contents))))
-        (if (and description
-                 (char-or-string-p description) ; Temp fix for bug in org parser
-                 (not (string-equal description ","))) ; Handle another org
-                                                       ; parser bug. Parser
-                                                       ; thinks "," is a
-                                                       ; link when used in e.g.,
-                                                       ; or i.e.,
-            (org-brain--insert-resource-button
-             (org-brain--handle-relative-path raw-link)
-             description
-             (1+ (org-element-property :level headline)))
-          (org-brain-log (format "using raw-link: %s as description"
-                                 raw-link))
+        (if (and (not (org-brain--empty-string-p description))
+                 (char-or-string-p description) ; Temp fix: handle org parser
+                                                ; bug.
+                 (not (string-equal description ","))) ; Temp fix: handle org
+                                                       ; parser bug.
           (org-brain--insert-resource-button
            (org-brain--handle-relative-path raw-link)
-           raw-link
-           (1+ (org-element-property :level headline))))))
+           description
+           (1+ (org-element-property :level headline)))
+          (org-brain-log (format "Using raw-link: %s as description"
+                                   raw-link))
+            (org-brain--insert-resource-button
+             (org-brain--handle-relative-path raw-link)
+             raw-link
+             (1+ (org-element-property :level headline))))))
     nil nil 'headline))         ; No recursion on headline, i.e., just
                                 ; get the links for the current
                                 ; headline, but not any of its children

--- a/org-brain.el
+++ b/org-brain.el
@@ -725,9 +725,12 @@ PARENT can hold multiple entries, by using `org-brain-batch-separator'."
 
 (defun org-brain-visualize-add-or-change-title ()
   "In current org-brain ENTRY, add \"#+TITLE:\" with title value acquired
-  from user."
+  and required from user."
   (interactive)
   (let ((title (read-string "Title: ")))
+    (loop while (empty-string-p title) do
+          (setq title (read-string
+                       "Title must have a value, please enter title: ")))
     (org-brain-add-or-change-title title org-brain--visualizing-entry)
     (when (string-equal (buffer-name) "*org-brain*")
       (revert-buffer))))

--- a/org-brain.el
+++ b/org-brain.el
@@ -756,6 +756,27 @@ PARENT can hold multiple entries, by using `org-brain-batch-separator'."
             (insert (format "#+TITLE: %s\n" title))
             (save-buffer))))))
 
+(defun org-brain-visualize-remove-title ()
+  "Remove \"#+TITLE:\" line from entry last visited by
+  `org-brain-visualize' if it exists."
+  (interactive)
+  (org-brain-remove-title org-brain--visualizing-entry)
+  (when (string-equal (buffer-name) "*org-brain*")
+    (revert-buffer)))
+
+(defun org-brain-remove-title (entry)
+  "In org-brain ENTRY, remove \"#+TITLE:\" if it exists."
+  (let ((entry-path (org-brain-entry-path entry)))
+    (org-save-all-org-buffers)
+    (with-current-buffer (find-file-noselect entry-path)
+      (when (assoc "TITLE" (org-brain-keywords entry))
+        (goto-char (point-min))
+        (re-search-forward "^#\\+TITLE:.*$")
+        (beginning-of-line)
+        (when (looking-at "^#\\+TITLE:.*$")
+            (kill-line)
+            (save-buffer))))))
+
 (define-derived-mode org-brain-visualize-mode
   special-mode  "Org-brain Visualize"
   "Major mode for `org-brain-visualize'.
@@ -767,6 +788,7 @@ PARENT can hold multiple entries, by using `org-brain-batch-separator'."
 (define-key org-brain-visualize-mode-map "P" 'org-brain-visualize-add-pin)
 (define-key org-brain-visualize-mode-map "R" 'org-brain-visualize-remove-pin)
 (define-key org-brain-visualize-mode-map "t" 'org-brain-visualize-add-or-change-title)
+(define-key org-brain-visualize-mode-map "T" 'org-brain-visualize-remove-title)
 (define-key org-brain-visualize-mode-map "j" 'forward-button)
 (define-key org-brain-visualize-mode-map "k" 'backward-button)
 (define-key org-brain-visualize-mode-map [?\t] 'forward-button)

--- a/org-brain.el
+++ b/org-brain.el
@@ -996,9 +996,10 @@ PARENT can hold multiple entries, by using `org-brain-batch-separator'."
                      raw-link))))))))
   (org-brain-log (format "Visualizing entry: %s" org-brain--visualizing-entry))
   (org-brain-log (format "Link to search for: %s" link))
-  (re-search-forward (format "^ +- *%s" link))
-  (backward-char 1)
-  (push-button))
+  (when (re-search-forward (format "^ +- *%s\\|^*+ +\\[\\[.*\\]\\[%s"
+                                   link link))
+    (backward-char 1)
+    (push-button)))
 
 (define-derived-mode org-brain-visualize-mode
   special-mode  "Org-brain Visualize"

--- a/org-brain.el
+++ b/org-brain.el
@@ -66,7 +66,7 @@ This will be used by `org-brain-new-child'."
 
 ;;; Utils
 (defun org-brain-flatten (obj)
-  "Return a 1-dimensional list, OBJ, given an n-dimensional list."
+  "Return a 1-dimensional list, given an n-dimensional list OBJ."
   (do* ((result (list obj))
         (node result))
        ((null node) (delete nil result))

--- a/org-brain.el
+++ b/org-brain.el
@@ -142,6 +142,7 @@ This will be used by `org-brain-new-child'."
   (org-brain-log "Invalidating org-brain pin cache...")
   (setq org-brain-pins-cache nil))
 
+;;;###autoload
 (defun org-brain-build-caches ()
   "(Optional) It is not necessary to use this function as the
   caches are built lazily, automatically. However, this is just
@@ -330,12 +331,14 @@ You can choose to EXCLUDE an entry from the list."
     (let ((child-to-remove
            (completing-read "Child to remove: "
             (org-brain-children entry))))
-      (with-current-buffer (get-file-buffer entry-path)
+      (with-current-buffer (find-file-noselect entry-path)
           (goto-char (point-min))
           (save-excursion
-            (re-search-forward (format "^\\*.*:%s:.*$" org-brain-children-tag-default-name) nil t)
+            (re-search-forward
+             (format "^\\*.*:%s:.*$" org-brain-children-tag-default-name) nil t)
             (let ((bound (outline-next-heading)))
-              (re-search-backward (format "^\\*.*:%s:.*$" org-brain-children-tag-default-name) nil t)
+              (re-search-backward
+               (format "^\\*.*:%s:.*$" org-brain-children-tag-default-name) nil t)
               (beginning-of-line)
               (re-search-forward
                (format "^ *- \\[\\[brain:%s.*$" child-to-remove) bound t)

--- a/org-brain.el
+++ b/org-brain.el
@@ -595,22 +595,24 @@ interactively."
               (goto-line 4)
               (mapc
                (lambda (child)
-                 (picture-forward-column col-start)
-                 (insert (make-string
-                          (1+ (length parent-title)) ?\ ) "/ ")
-                 (org-brain--insert-visualize-button child)
-                 (setq max-width (max max-width (current-column)))
-                 (newline (forward-line 1)))
+                 (unless (string-equal entry child)
+                   (picture-forward-column col-start)
+                   (insert (make-string
+                            (1+ (length parent-title)) ?\ ) "/ ")
+                   (org-brain--insert-visualize-button child)
+                   (setq max-width (max max-width (current-column)))
+                   (newline (forward-line 1))))
                children)
               (goto-line 4)
-              (forward-line (1- (length children)))
+              (forward-line (- (length children) 2))
               (picture-forward-column col-start)
               (push (cons (picture-current-line)
                           (+ (current-column) (/ (length parent-title) 2)))
                     parent-positions)
               (org-brain--insert-visualize-button parent)
               (setq max-width (max max-width (current-column)))
-              (when children
+              (when (and children
+                         (> (length children) 1))
                 (delete-char (length parent-title)))))
           (org-brain-parents entry))
     ;; Draw lines

--- a/org-brain.el
+++ b/org-brain.el
@@ -587,9 +587,9 @@ interactively."
   (let ((parent-positions nil)
         (max-width 0))
     (mapc (lambda (parent)
-            (let ((children (set-difference
+            (let ((children (cl-set-difference
                              (org-brain-children parent)
-                             ignored-siblings))
+                             ignored-siblings :test #'equal))
                   (col-start (+ 3 max-width))
                   (parent-title (org-brain-title parent)))
               (goto-line 4)

--- a/org-brain.el
+++ b/org-brain.el
@@ -719,10 +719,8 @@ interactively."
              (org-brain--handle-relative-path raw-link)
              description
              (1+ (org-element-property :level headline)))
-          (unless (string-equal raw-link ",") ; Temp fix: handle org parser
-                                              ; bug.
-            (org-brain-log (format "Using raw-link: %s as description"
-                                   raw-link))
+          (unless (string-equal raw-link ",") ; Temp fix: handle org
+                                              ; parser bug.
             (org-brain--insert-resource-button
              (org-brain--handle-relative-path raw-link)
              raw-link

--- a/org-brain.el
+++ b/org-brain.el
@@ -214,14 +214,14 @@ If RELATIVE is t, then return relative paths and remove org extension."
                     org-brain-path))
 
 ;;; Data serialization functions
-(defun save-data (file data)
+(defun org-brain--save-data (file data)
   "Save lisp DATA, i.e., sexps, to FILE."
   (with-temp-file file
     (let ((standard-output (current-buffer))
           (print-circle t))  ; Allow circular data
       (prin1 data))))
 
-(defun load-data (file)
+(defun org-brain--load-data (file)
   "Load lisp data, i.e., sexps, from FILE."
   (when (file-exists-p file)
     (with-temp-buffer
@@ -231,33 +231,33 @@ If RELATIVE is t, then return relative paths and remove org extension."
 (defun org-brain--save-children ()
   "Save the children. Write data into the file specified by
   `org-brain--children-file'."
-  (save-data org-brain--children-file
+  (org-brain--save-data org-brain--children-file
              (org-brain--hash-to-list org-brain-children-cache)))
 
 (defun org-brain--save-parents ()
   "Save the parents. Write data into the file specified by
   `org-brain--parents-file'."
-  (save-data org-brain--parents-file
+  (org-brain--save-data org-brain--parents-file
              (org-brain--hash-to-list org-brain-parents-cache)))
 
 (defun org-brain--save-pins ()
   "Save the pins. Write data into the file specified by
   `org-brain--pins-file'."
-  (save-data org-brain--pins-file org-brain-pins-cache))
+  (org-brain--save-data org-brain--pins-file org-brain-pins-cache))
 
 (defun org-brain--load-children ()
   "Load children cache from file."
   (setq org-brain-children-cache
-        (org-brain--list-to-hash (load-data org-brain--children-file))))
+        (org-brain--list-to-hash (org-brain--load-data org-brain--children-file))))
 
 (defun org-brain--load-parents ()
   "Load parents cache from file."
   (setq org-brain-parents-cache
-        (org-brain--list-to-hash (load-data org-brain--parents-file))))
+        (org-brain--list-to-hash (org-brain--load-data org-brain--parents-file))))
 
 (defun org-brain--load-pins ()
   "Load pins cache from file."
-  (setq org-brain-pins-cache (load-data org-brain--pins-file)))
+  (setq org-brain-pins-cache (org-brain--load-data org-brain--pins-file)))
 
 (defun org-brain-parents (entry &optional exclude)
   "Get list of org-brain parent entries linked to ENTRY.

--- a/org-brain.el
+++ b/org-brain.el
@@ -725,7 +725,7 @@ interactively."
                                               ; parser bug.
             (org-brain--insert-resource-button
              (org-brain--handle-relative-path raw-link)
-             raw-link
+             (org-link-unescape raw-link)
              (1+ (org-element-property :level headline)))))))
     nil nil 'headline))         ; No recursion on headline, i.e., just
                                 ; get the links for the current

--- a/org-brain.el
+++ b/org-brain.el
@@ -307,26 +307,31 @@ You can choose to EXCLUDE an entry from the list."
     (unless (file-exists-p entry-path)
       (with-temp-file entry-path
         (make-directory (file-name-directory entry-path) t)))
-    (or (org-map-entries (lambda ()
-                           (end-of-line)
-                           (insert (format "\n- [[brain:%s][%s]]" child (org-brain-title child)))
-                           (save-buffer))
-                         (format "+%s" org-brain-children-tag-default-name)
-                         (list entry-path))
-        (with-current-buffer (get-file-buffer entry-path)
+    (with-current-buffer (find-file-noselect entry-path)
+      (goto-char (point-min))
+      (save-excursion
+        (if (re-search-forward
+               (format "^\\*.*:%s:.*$" org-brain-children-tag-default-name)
+               nil t)
+            (progn
+              (end-of-line)
+              (insert (format "\n- [[brain:%s][%s]]"
+                              child (org-brain-title child)))
+              (save-buffer))
           (goto-char (point-max))
           (insert (format "\n\n* %s    :%s:\n- [[brain:%s][%s]]"
-                          org-brain-children-tag-default-name
                           org-brain-children-headline-default-name
+                          org-brain-children-tag-default-name
                           child
                           (org-brain-title child)))
-          (save-buffer)))))
+          (save-buffer))))))
 
 (defun org-brain-remove-child (entry child)
   "In org-brain ENTRY, remove CHILD link. This doesn't delete the
   file pointed to by the link, just the link."
   (let ((entry-path (org-brain-entry-path entry)))
     (org-save-all-org-buffers)
+    (org-brain-invalidate-child-cache-entry entry)
     (with-current-buffer (find-file-noselect entry-path)
       (goto-char (point-min))
       (save-excursion
@@ -338,8 +343,7 @@ You can choose to EXCLUDE an entry from the list."
         (beginning-of-line)
         (looking-at (format "^ *- \\[\\[brain:%s.*$" child))
         (kill-line 1)
-        (save-buffer)
-        (org-brain-invalidate-child-cache-entry entry)))))
+        (save-buffer)))))
 
 (defun org-brain-insert-visualize-button (entry)
   "Insert a button, which runs `org-brain-visualize' on ENTRY when clicked."
@@ -708,7 +712,6 @@ CHILD can hold multiple entries, by using `org-brain-batch-separator'."
    org-brain--visualizing-entry)        ; Invalidate cache
   (dolist (c (split-string child org-brain-batch-separator t " +"))
     (org-brain-remove-child org-brain--visualizing-entry c))
-  ;; (org-brain-remove-child org-brain--visualizing-entry)
   (when (string-equal (buffer-name) "*org-brain*")
     (revert-buffer)))
 

--- a/org-brain.el
+++ b/org-brain.el
@@ -110,12 +110,14 @@ This will be used by `org-brain-new-child'."
   (setq org-brain-files-cache nil))
 
 (defun org-brain-invalidate-parent-cache-entry (entry)
-  (org-brain-log (format "Invalidating org-brain parent cache entry: %s ..." entry))
+  (org-brain-log
+   (format "Invalidating org-brain parent cache entry: %s ..." entry))
   (setq org-brain-parents-cache
         (remove* entry org-brain-parents-cache :test #'equal :key #'car)))
 
 (defun org-brain-invalidate-child-cache-entry (entry)
-  (org-brain-log (format "Invalidating org-brain child cache entry: %s ..." entry))
+  (org-brain-log
+   (format "Invalidating org-brain child cache entry: %s ..." entry))
   (setq org-brain-children-cache
         (remove* entry org-brain-children-cache :test #'equal :key #'car)))
 
@@ -204,7 +206,6 @@ If RELATIVE is t, then return relative paths and remove org extension."
 (defun org-brain-children (entry &optional exclude)
   "Get list of org-brain entries linked to from ENTRY.
 You can choose to EXCLUDE an entry from the list."
-  ;; TODO Handle exclude
   (if (and org-brain-children-cache
            (assoc entry org-brain-children-cache))
       (cdr (assoc entry org-brain-children-cache))


### PR DESCRIPTION
"S" to search in visualize interface was failing to find a link that was in a headline, e.g., "This is a link description"

*** [[id:someidhere][This is a link description]]

It'll now handle that as well as finding the link description when the link is rendered as a regular org-brain visualize link aka

 - [[http://somewhere.com][This is a link description]]
