### PR TITLE
Add option to visualize only one child per line, instead of filling up to `fill-column'

### DIFF
--- a/org-brain.el
+++ b/org-brain.el
@@ -154,6 +154,13 @@ Doing so allows for adding multiple entries at once."
   :group 'org-brain
   :type '(string))
 
+(defcustom org-brain-visualize-one-child-per-line nil
+  "If non-nil, each child of the visualized entry is listed on
+its own line. If nil (default), children are filled up to the
+`fill-column'."
+  :group 'org-brain
+  :type '(boolean))
+
 ;;;###autoload
 (defun org-brain-update-id-locations ()
   "Scan `org-brain-files' using `org-id-update-id-locations'."
@@ -1441,8 +1448,9 @@ Helper function for `org-brain-visualize'."
     (insert "\n\n")
     (dolist (child children)
       (let ((child-title (org-brain-title child)))
-        (when (> (+ (current-column) (length child-title))
-                 fill-column)
+        (when (or org-brain-visualize-one-child-per-line
+				  (> (+ (current-column) (length child-title))
+					 fill-column))
           (insert "\n"))
         (org-brain-insert-visualize-button child)
         (insert "  ")))))


### PR DESCRIPTION
I've been wishing for this for a while. I prefer having one child per line, so it's easier for me to visually scan through quickly. The default behavior is exactly how it was before.