### PR TITLE
Speed up entry listing when visualizing

### DIFF
--- a/org-brain.el
+++ b/org-brain.el
@@ -269,10 +269,10 @@ Ignores \"dotfiles\"."
 (defun org-brain-headline-entries ()
   "Get all org-brain headline entries."
   (unless org-id-locations (org-id-locations-load))
-  (save-window-excursion
-    (let (ids)
-      (dolist (file (org-brain-files) ids)
-        (find-file file)
+  (let (ids)
+    (dolist (file (org-brain-files) ids)
+      (with-current-buffer
+        (find-file-noselect file)
         ;; It is faster to loop through ALL entries in all org-brain-files and
         ;; discard the ones that don't have IDS, than it is to seek out the
         ;; entries in `org-id-locations' one by one.

--- a/org-brain.el
+++ b/org-brain.el
@@ -205,16 +205,16 @@ its own line. If nil (default), children are filled up to the
 (defun org-brain-id-exclude-taggedp (id)
   "Return t if ID is tagged as being excluded from org-brain."
   (org-with-point-at (org-id-find id t)
-	(org-brain-entry-at-point-excludedp)))
+    (org-brain-entry-at-point-excludedp)))
 
 (defun org-brain-entry-at-point-excludedp ()
   "Return t if the entry at point is tagged as being excluded
 from org-brain."
   (let ((tags (org-get-tags-at)))
-	(or (member org-brain-exclude-tree-tag tags)
-		(and (member org-brain-exclude-children-tag tags)
-			 (not (member org-brain-exclude-children-tag
-						  (org-get-tags-at nil t)))))))
+    (or (member org-brain-exclude-tree-tag tags)
+        (and (member org-brain-exclude-children-tag tags)
+             (not (member org-brain-exclude-children-tag
+                          (org-get-tags-at nil t)))))))
 
 (defun org-brain-save-data ()
   "Save data to `org-brain-data-file'."
@@ -270,24 +270,24 @@ Ignores \"dotfiles\"."
   "Get all org-brain headline entries."
   (unless org-id-locations (org-id-locations-load))
   (save-window-excursion
-	(let (ids)
-	  (dolist (file (org-brain-files) ids)
-		(find-file file)
-		;; It is faster to loop through ALL entries in all org-brain-files and
-		;; discard the ones that don't have IDS, than it is to seek out the
-		;; entries in `org-id-locations' one by one.
-		(org-map-entries
-		 (lambda ()
-		   (let ((id (org-entry-get (point) "ID"))
-				 (excluded (org-brain-entry-at-point-excludedp)))
-			 (when (and id (not excluded))
-			   (push (list
-					  (org-brain-path-entry-name file)
-					  (org-entry-get (point) "ITEM")
-					  id)
-					 ids)))
-		   nil 'file)))
-	  ids)))
+    (let (ids)
+      (dolist (file (org-brain-files) ids)
+        (find-file file)
+        ;; It is faster to loop through ALL entries in all org-brain-files and
+        ;; discard the ones that don't have IDS, than it is to seek out the
+        ;; entries in `org-id-locations' one by one.
+        (org-map-entries
+         (lambda ()
+           (let ((id (org-entry-get (point) "ID"))
+                 (excluded (org-brain-entry-at-point-excludedp)))
+             (when (and id (not excluded))
+               (push (list
+                      (org-brain-path-entry-name file)
+                      (org-entry-get (point) "ITEM")
+                      id)
+                     ids)))
+           nil 'file)))
+      ids)))
 
 (defun org-brain-entry-from-id (id)
   "Get entry from ID."
@@ -1505,8 +1505,8 @@ Helper function for `org-brain-visualize'."
     (dolist (child children)
       (let ((child-title (org-brain-title child)))
         (when (or org-brain-visualize-one-child-per-line
-				  (> (+ (current-column) (length child-title))
-					 fill-column))
+                  (> (+ (current-column) (length child-title))
+                     fill-column))
           (insert "\n"))
         (org-brain-insert-visualize-button child)
         (insert "  ")))))

--- a/org-brain.el
+++ b/org-brain.el
@@ -210,7 +210,7 @@ its own line. If nil (default), children are filled up to the
 (defun org-brain-entry-at-point-excludedp ()
   "Return t if the entry at point is tagged as being excluded
 from org-brain."
-  (let ((tags (org-get-tags)))
+  (let ((tags (org-get-tags-at)))
 	(or (member org-brain-exclude-tree-tag tags)
 		(and (member org-brain-exclude-children-tag tags)
 			 (not (member org-brain-exclude-children-tag

--- a/org-brain.el
+++ b/org-brain.el
@@ -278,9 +278,8 @@ Ignores \"dotfiles\"."
         ;; entries in `org-id-locations' one by one.
         (org-map-entries
          (lambda ()
-           (let ((id (org-entry-get (point) "ID"))
-                 (excluded (org-brain-entry-at-point-excludedp)))
-             (when (and id (not excluded))
+           (let ((id (org-entry-get (point) "ID")))
+             (when (and id (not (org-brain-entry-at-point-excludedp)))
                (push (list
                       (org-brain-path-entry-name file)
                       (org-entry-get (point) "ITEM")

--- a/org-brain.el
+++ b/org-brain.el
@@ -205,11 +205,16 @@ its own line. If nil (default), children are filled up to the
 (defun org-brain-id-exclude-taggedp (id)
   "Return t if ID is tagged as being excluded from org-brain."
   (org-with-point-at (org-id-find id t)
-    (let ((tags (org-get-tags)))
-      (or (member org-brain-exclude-tree-tag tags)
-          (and (member org-brain-exclude-children-tag tags)
-               (not (member org-brain-exclude-children-tag
-                            (org-get-tags-at nil t))))))))
+	(org-brain-entry-at-point-excludedp)))
+
+(defun org-brain-entry-at-point-excludedp ()
+  "Return t if the entry at point is tagged as being excluded
+from org-brain."
+  (let ((tags (org-get-tags)))
+	(or (member org-brain-exclude-tree-tag tags)
+		(and (member org-brain-exclude-children-tag tags)
+			 (not (member org-brain-exclude-children-tag
+						  (org-get-tags-at nil t)))))))
 
 (defun org-brain-save-data ()
   "Save data to `org-brain-data-file'."

--- a/org-brain.el
+++ b/org-brain.el
@@ -205,7 +205,7 @@ its own line. If nil (default), children are filled up to the
 (defun org-brain-id-exclude-taggedp (id)
   "Return t if ID is tagged as being excluded from org-brain."
   (org-with-point-at (org-id-find id t)
-    (let ((tags (org-get-tags-at)))
+    (let ((tags (org-get-tags)))
       (or (member org-brain-exclude-tree-tag tags)
           (and (member org-brain-exclude-children-tag tags)
                (not (member org-brain-exclude-children-tag


### PR DESCRIPTION
I found that the main bottleneck when starting org-brain (such as when calling `org-brain-visualize`) was collecting the entries.

On my computer, these patches reduce the execution time of `org-brain-visualize` from over 10 seconds to just over 1.5 seconds. Much more comfortable! :)