### PR TITLE
Support for editing the org-brain-entry buffer

### DIFF
--- a/org-brain.el
+++ b/org-brain.el
@@ -414,14 +414,16 @@ Only get the body text, unless ALL-DATA is t."
               (goto-char (point-min))
               (or (outline-next-heading)
                   (goto-char (point-max)))
-              (buffer-substring-no-properties
-               (or (unless all-data
-                     (save-excursion
-                       (when (re-search-backward "^[#:*]" nil t)
-                         (end-of-line)
-                         (point))))
-                   (point-min))
-               (point)))
+              (let ((beg (or (unless all-data
+                               (save-excursion
+                                 (when (re-search-backward "^[#:*]" nil t)
+                                   (end-of-line)
+                                   (point))))
+                             (point-min)))
+                    (end (point)))
+                (setq src-beg beg)
+                (setq src-end end)
+                (buffer-substring-no-properties beg end)))
           ;; Headline entry
           (org-with-point-at (org-brain-entry-marker entry)
             (let ((tags (org-get-tags-at nil t)))


### PR DESCRIPTION
Updates the entry in the corresponding `.org` file when the
`org-brain-entry` is saved.

It's a bit hacky, but works for me. 