### PR TITLE
FIX: revert-buffer-function should only be set for org-brain buffers

### DIFF
--- a/org-brain.el
+++ b/org-brain.el
@@ -1385,7 +1385,7 @@ See `org-brain-add-resource'."
   special-mode  "Org-brain Visualize"
   "Major mode for `org-brain-visualize'.
 \\{org-brain-visualize-mode-map}"
-  (setq revert-buffer-function #'org-brain-visualize-revert)
+  (setq-local revert-buffer-function #'org-brain-visualize-revert)
   (add-function :before-until (local 'eldoc-documentation-function)
                 #'org-brain-visualize-eldoc-function))
 


### PR DESCRIPTION
As-is, ALL modes are being affected. (Calling `revert-buffer` hasn't been
working for me lately, and this appears to be why -- all buffers are using
org-brain's `revert-buffer-function`.)

According to the Emacs online documentation, it's common for special modes like dired (or org-brain) to set this function locally, to redraw their buffers.