### PR TITLE
Widen target buffer during org-brain-goto

### DIFF
--- a/org-brain.el
+++ b/org-brain.el
@@ -908,6 +908,7 @@ Unless GOTO-FILE-FUNC is nil, use `pop-to-buffer-same-window' for opening the en
   (let ((marker (org-brain-entry-marker entry)))
     (apply (or goto-file-func #'pop-to-buffer-same-window)
            (list (marker-buffer marker)))
+    (widen)
     (goto-char (marker-position marker))
     (org-show-entry))
   entry)


### PR DESCRIPTION
Otherwise it may not work as expected if buffer is narrowed prior to calling
org-brain-goto.