### PR TITLE
add a link in the readme

### DIFF
--- a/README.org
+++ b/README.org
@@ -172,7 +172,7 @@ available in =org-brain-visualize=:
 | d          | =org-brain-delete-entry=             | Choose an entry to delete.                                   |
 | l          | =org-brain-visualize-add-resource=   | Add a new resource link in entry                             |
 | C-y        | =org-brain-visualize-paste-resource= | Add a new resource link from clipboard                       |
-| a          | =org-brain-visualize-attach=         | Run =org-attach= on entry (headline entries only)            |
+| a          | =org-brain-visualize-attach=         | Run =org-attach= on entry ([[#headline-and-file-entries][org-brain headline entries]] only)            |
 | A          | =org-brain-archive=                  | Archive the entry (headline entries only)                    |
 | o          | =org-brain-goto-current=             | Open current entry for editing                               |
 | O          | =org-brain-goto=                     | Choose and edit one of your =org-brain= entries              |


### PR DESCRIPTION
Point the careless reader to the definition of an org-brain headline entry