### PR TITLE
Add org-brain-visualize-parent

### DIFF
--- a/org-brain.el
+++ b/org-brain.el
@@ -1128,6 +1128,14 @@ If ALL is nil, choose only between externally linked parents."
                    nil t)))
 
 ;;;###autoload
+(defun org-brain-visualize-parent (entry)
+  "Visualize the first parent of ENTRY.
+This allows the user to quickly jump up the hierarchy."
+  (interactive (list (org-brain-entry-at-pt)))
+  (when-let ((parent (car (org-brain-parents entry))))
+    (org-brain-visualize parent)))
+
+;;;###autoload
 (defun org-brain-goto-friend (entry)
   "Goto a friend of ENTRY.
 If run interactively, get ENTRY from context."
@@ -1757,6 +1765,7 @@ See `org-brain-add-resource'."
 (define-key org-brain-visualize-mode-map "t" 'org-brain-set-title)
 (define-key org-brain-visualize-mode-map "j" 'forward-button)
 (define-key org-brain-visualize-mode-map "k" 'backward-button)
+(define-key org-brain-visualize-mode-map "u" 'org-brain-visualize-parent)
 (define-key org-brain-visualize-mode-map [?\t] 'forward-button)
 (define-key org-brain-visualize-mode-map [backtab] 'backward-button)
 (define-key org-brain-visualize-mode-map "o" 'org-brain-goto-current)


### PR DESCRIPTION
This patch adds a new `org-brain-visualize-parent` command, which visualizes the first parent of an entry. It binds the command to "u" in the org-brain keymap.

The idea here is that often I want to quickly jump to an entry's parent, but with the default keybindings I might have to tab through a bunch of siblings to get the point onto the parent button.

Also sometimes I want to just jump up the hierarchy quickly, which this allows me to do.