### PR TITLE
Improve org-brain-rename-file

### DIFF
--- a/org-brain.el
+++ b/org-brain.el
@@ -1188,8 +1188,9 @@ not contain `org-brain-files-extension'."
         (org-brain--remove-relationships file-entry)
         (org-save-all-org-buffers)
         (make-directory (file-name-directory newpath) t)
-        (with-temp-file newpath (insert-file-contents oldpath))
-        (org-brain-delete-entry file-entry t)
+        (if (vc-backend oldpath)
+            (vc-rename-file oldpath newpath)
+          (rename-file oldpath newpath))
         (org-brain-update-id-locations)
         (dolist (child children)
           (org-brain-add-relationship new-name child))
@@ -1197,6 +1198,9 @@ not contain `org-brain-files-extension'."
           (org-brain-add-relationship parent new-name))
         (dolist (friend friends)
           (org-brain--internal-add-friendship new-name friend))
+        (when (equal file-entry org-brain--vis-entry)
+          (setq org-brain--vis-entry new-name))
+        (org-brain--revert-if-visualizing)
         (message "Renamed %s to %s" file-entry new-name)))))
 
 ;;;###autoload


### PR DESCRIPTION
org-brain-rename-file currently fails in quite a bad way if the org-brain directory is under git version control. Within a git repo, renaming does the following:

1. Remove relationships from the old-name file
2. Copy the old-name file into a new-name file
3. Delete the old-name file with vc-delete-file

The problem is that vc-delete-file fails if the file to be deleted is dirty, which it generally is, since its relationships have been removed just prior to deletion.

The solution is to use vc-rename-file, which succeeds with a dirty file. It also has the benefit of reliably recording the file rename in the git repo.

This patch also ensures that visualization is consistent after the file rename occurs.