### PR TITLE
org-brain-add-resource pops stored links just like org-insert-link

### DIFF
--- a/org-brain.el
+++ b/org-brain.el
@@ -1647,6 +1647,9 @@ If ENTRY is omitted, try to get it from context or prompt for it."
              ()
              (unless (and link (not prompt))
                (setq link (read-string "Insert link: " link))
+               (unless org-keep-stored-link-after-insertion
+                 (setq org-stored-links (delq (assoc link org-stored-links)
+                                              org-stored-links)))
                (when (string-match org-bracket-link-regexp link)
                  (let ((linkdesc (match-string 3 link)))
                    (when (and (not description) linkdesc)


### PR DESCRIPTION
I expected `org-brain-add-resource` to behave roughly like `org-insert-link` (especially since the docs mention using it) but it was leaving the inserted links in the `org-stored-links` regardless of the `org-keep-stored-link-after-insertion` value. This patch should make it more consistent.

I placed this code right after reading the link and before reading its description, so that cancelling the command between them will still pop the link from the list, just like in `org-insert-link`. I was not sure whether it should go before or after the regexp-related code between them though, so please use your discretion.