### PR TITLE
Remove extra newlines from file-entry headers

### DIFF
--- a/org-brain.el
+++ b/org-brain.el
@@ -877,6 +877,7 @@ PROPERTY could for instance be BRAIN_CHILDREN."
         (re-search-forward (concat " " (org-brain-entry-identifier child)))
         (replace-match "")
         (org-brain-remove-line-if-matching "^#\\+BRAIN_CHILDREN:[[:space:]]*$")
+        (org-brain-remove-line-if-matching "^[[:space:]]*$")
         (save-buffer))
     ;; Parent = Headline
     (org-entry-remove-from-multivalued-property (org-brain-entry-marker parent)
@@ -891,6 +892,7 @@ PROPERTY could for instance be BRAIN_CHILDREN."
         (re-search-forward (concat " " (org-brain-entry-identifier parent)))
         (replace-match "")
         (org-brain-remove-line-if-matching "^#\\+BRAIN_PARENTS:[[:space:]]*$")
+        (org-brain-remove-line-if-matching "^[[:space:]]*$")
         (save-buffer))
     ;; Child = Headline
     (org-entry-remove-from-multivalued-property (org-brain-entry-marker child)
@@ -1042,6 +1044,7 @@ If run interactively, use `org-brain-entry-at-pt' as ENTRY1 and prompt for ENTRY
           (re-search-forward (concat " " (org-brain-entry-identifier entry2)))
           (replace-match "")
           (org-brain-remove-line-if-matching "^#\\+BRAIN_FRIENDS:[[:space:]]*$")
+          (org-brain-remove-line-if-matching "^[[:space:]]*$")
           (save-buffer))
       ;; Entry2 = Headline
       (org-entry-remove-from-multivalued-property (org-brain-entry-marker entry1)


### PR DESCRIPTION
- Two newlines are inserted whenever =#+BRAIN_CHILDREN:= et al
  are inserted in file-entry headers, but only one is removed
  when an empty header is deleted. This commit removes these extra newlines.

I noticed this when I was doing a bunch of refiling work, which I'll open PRs about in due time. Refiling entries in and out of files over and over would create a bunch of blank lines as the header entries were added (with an extra newline) and removed (leaving the newline there).