### PR TITLE
History list always contains the current entry

### DIFF
--- a/org-brain.el
+++ b/org-brain.el
@@ -1869,9 +1869,9 @@ See `org-brain-add-resource'."
 (defun org-brain-visualize-back ()
   "Go back to the previously visualized entry."
   (interactive)
-  (pop org-brain--vis-history)
-  (if org-brain--vis-history
-      (org-brain-visualize (car org-brain--vis-history) nil t)
+  (if (cadr org-brain--vis-history)
+      (progn (pop org-brain--vis-history)
+             (org-brain-visualize (car org-brain--vis-history) nil t))
     (error "No further history")))
 
 (defun org-brain-visualize-revert (_ignore-auto _noconfirm)


### PR DESCRIPTION
This patch ensures that the current entry is always at the head of the history list. Attempts to go further back in history than the current entry will fail. Previously going back could empty the history list, which would leave org-brain in a slightly strange state of visiting an entry but not considering that entity part of the visitation history.

Commit notes:

- Prevent org-brain-visualize-back from popping the current entry
  if there is no entry before it to go back to.