### PR TITLE
Bug fix: Ignore errors when calling kill-whole-line

### DIFF
--- a/org-brain.el
+++ b/org-brain.el
@@ -866,7 +866,7 @@ PROPERTY could for instance be BRAIN_CHILDREN."
   "Delete current line, if matching REGEX."
   (when (string-match regex (buffer-substring (line-beginning-position)
                                               (line-end-position)))
-    (kill-whole-line)))
+    (ignore-errors (kill-whole-line))))
 
 (defun org-brain-remove-relationship (parent child)
   "Remove external relationship between PARENT and CHILD."


### PR DESCRIPTION
#181 introduced a bug, which manifests when you remove the the last `BRAIN_CHILDREN` entry, and the `BRAIN_CHILDREN` line is the last line of the file. The test for the blank line succeeds, but the call to `kill-whole-line` errors out. It errors out in quite a bad way, because this happens in the middle of relinking functions, so the error can leave entries in an inconsistent half-linked state.

Commit notes:

- org-brain-remove-line-if-matching will fail with a mysterious
  "end of buffer" message if passed a regex that matches a blank line
  when point is at the end of the buffer. This ignores these errors.