### PR TITLE
Add file-entry & local faces. Improve select face

### DIFF
--- a/org-brain.el
+++ b/org-brain.el
@@ -252,31 +252,60 @@ Insert links using `org-insert-link'."
 
 (defface org-brain-button
   '((t . (:inherit button)))
-  "Face for buttons in the org-brain visualize buffer.")
+  "Face for header-entry buttons in the org-brain visualize buffer.")
 
 (defface org-brain-parent
   '((t . (:inherit (font-lock-builtin-face org-brain-button))))
-  "Face for the entries' parent nodes.")
+  "Face for the entries' linked header-entry parent nodes.")
+
+(defface org-brain-local-parent
+  '((t . (:inherit org-brain-parent :weight bold)))
+  "Face for the entries' local header-entry parent nodes.")
 
 (defface org-brain-child
   '((t . (:inherit org-brain-button)))
-  "Face for the entries' child nodes.")
+  "Face for the entries' linked header-entry child nodes.")
+
+(defface org-brain-local-child
+  '((t . (:inherit org-brain-child :weight bold)))
+  "Face for the entries' local header-entry child nodes.")
 
 (defface org-brain-sibling
   '((t . (:inherit org-brain-child)))
-  "Face for the entries' sibling nodes.")
+  "Face for the entries' header-entry sibling nodes.")
+
+(defface org-brain-local-sibling
+  '((t . (:inherit org-brain-sibling :weight bold)))
+  "Face for the entries' local header-entry sibling nodes.
+An entry is a local sibling of another entry if they share a local parent.")
 
 (defface org-brain-friend
   '((t . (:inherit org-brain-button)))
-  "Face for the entries' friend nodes.")
+  "Face for the entries' header-entry friend nodes.")
 
 (defface org-brain-pinned
   '((t . (:inherit org-brain-button)))
-  "Face for pinned entries.")
+  "Face for pinned header entries.")
 
-(defface org-brain-selected
-  '((t . (:inherit org-brain-button)))
-  "Face for selected entries.")
+(defface org-brain-file-face-template
+  '((t . (:slant italic)))
+  "Attributes of this face are added to file-entry faces.")
+
+;; This needs to be here or defface complains that it is undefined.
+(defun org-brain-specified-face-attrs (face &optional frame)
+  "Return a plist of all face attributes of FACE that are not `unspecified'.
+If FRAME is not specified, `selected-frame' is used."
+  (cl-labels ((alist->plist (alist)
+                            (pcase alist
+                              ('nil nil)
+                              (`((,h1 . ,h2) . ,tail) `(,h1 . (,h2 . ,(alist->plist tail)))))))
+    (alist->plist (seq-filter
+                   (lambda (f) (not (equal (cdr f) 'unspecified)))
+                   (face-all-attributes face (or frame (selected-frame)))))))
+
+(defface org-brain-selected-face-template
+  `((t . ,(org-brain-specified-face-attrs 'highlight)))
+  "Attributes of this face are added to the faces of selected entries.")
 
 ;;;; API
 
@@ -1713,7 +1742,7 @@ Unless WANDER is t, `org-brain-stop-wandering' will be run."
               (ignore-errors (delete-char (- half-title-length)))))
           (setq entry-pos (point))
           (insert (propertize title
-                              'face 'org-brain-title
+                              'face (org-brain-display-face entry 'org-brain-title)
                               'aa2u-text t))
           (org-brain--vis-friends entry)
           (org-brain--vis-children entry)))
@@ -1787,6 +1816,21 @@ cancelled manually with `org-brain-stop-wandering'."
   (org-brain-title entry (or (not org-brain-visualizing-mind-map)
                              org-brain-cap-mind-map-titles)))
 
+(defun org-brain-display-face (entry &optional face)
+  "Return the final display face for ENTRY.
+Takes FACE as a starting face, or `org-brain-button' if FACE is not specified.
+Applies the attributes in `org-brain-selected-face-template'
+and `org-brain-file-face-template' as appropriate."
+  (let ((selected-face-attrs
+         (when (member entry org-brain-selected)
+           (org-brain-specified-face-attrs 'org-brain-selected-face-template)))
+        (file-face-attrs
+         (when (org-brain-filep entry)
+           (org-brain-specified-face-attrs 'org-brain-file-face-template))))
+    (append (list :inherit (or face 'org-brain-button))
+            selected-face-attrs
+            file-face-attrs)))
+
 (defun org-brain-insert-visualize-button (entry &optional face)
   "Insert a button, running `org-brain-visualize' on ENTRY when clicked."
   (insert-text-button
@@ -1796,9 +1840,7 @@ cancelled manually with `org-brain-stop-wandering'."
    'follow-link t
    'help-echo (when org-brain-show-descriptions (org-brain-description entry))
    'aa2u-text t
-   'face (if (member entry org-brain-selected)
-             'org-brain-selected
-           (or face 'org-brain-button))))
+   'face (org-brain-display-face entry face)))
 
 (defun org-brain-insert-resource-button (resource &optional indent)
   "Insert a new line with a RESOURCE button, indented by INDENT spaces."
@@ -1999,7 +2041,7 @@ Helper function for `org-brain-visualize'."
     (insert "SELECTED:")
     (dolist (selection (sort (copy-sequence org-brain-selected) org-brain-visualize-sort-function))
       (insert "  ")
-      (org-brain-insert-visualize-button selection 'org-brain-selected))
+      (org-brain-insert-visualize-button selection 'org-brain-pinned))
     (insert "\n")))
 
 (defun org-brain--hist-entries-to-draw (max-width hist width to-draw)
@@ -2054,7 +2096,12 @@ Helper function for `org-brain-visualize'."
            (lambda (child)
              (picture-forward-column col-start)
              (org-brain--insert-wire (make-string (1+ (string-width parent-title)) ?\ ) "+-")
-             (org-brain-insert-visualize-button child 'org-brain-sibling)
+             (org-brain-insert-visualize-button
+              child
+              (if (and (member (car parent) (org-brain--local-parent child))
+                       (member (car parent) (org-brain--local-parent entry)))
+                  'org-brain-local-sibling
+                'org-brain-sibling))
              (setq max-width (max max-width (current-column)))
              (newline (forward-line 1)))
            (sort children-links org-brain-visualize-sort-function))
@@ -2064,7 +2111,11 @@ Helper function for `org-brain-visualize'."
           (push (cons (picture-current-line)
                       (+ (current-column) (/ (string-width parent-title) 2)))
                 parent-positions)
-          (org-brain-insert-visualize-button (car parent) 'org-brain-parent)
+          (org-brain-insert-visualize-button
+           (car parent)
+           (if (member (car parent) (org-brain--local-parent entry))
+               'org-brain-local-parent
+             'org-brain-parent))
           (setq max-width (max max-width (current-column)))
           (when children-links
             (org-brain--insert-wire "-")
@@ -2112,12 +2163,15 @@ Helper function for `org-brain-visualize'."
   (when-let ((children (org-brain-children entry)))
     (insert "\n\n")
     (dolist (child (sort children org-brain-visualize-sort-function))
-      (let ((child-title (org-brain-title child)))
+      (let ((child-title (org-brain-title child))
+            (face (if (member entry (org-brain--local-parent child))
+                      'org-brain-local-child
+                    'org-brain-child)))
         (when (or org-brain-visualize-one-child-per-line
                   (> (+ (current-column) (length child-title))
                      fill-column))
           (insert "\n"))
-        (org-brain-insert-visualize-button child 'org-brain-child)
+        (org-brain-insert-visualize-button child face)
         (insert "  ")))))
 
 (defun org-brain--vis-friends (entry)


### PR DESCRIPTION
This patch adds support for file-entry faces, as well as for local-parent, local-child, and local-sibling faces. This implements some of the things that #125 requested. It also revamps how selected faces are computed so that selected, file-entry, and local faces can all stack on top of one another.

To avoid defining a separate file-entry face for each face (e.g., org-brain-file-parent, org-brain-file-child, org-brain-file-sibling, org-brain-file-pinned, etc.) we define a single face called `org-brain-file-face-template`. The non-unspecified attributes of this face (default is `:slant italic`) are applied to the names of all file entries during visualization by a new function called `org-brain-display-face`.

We use the same approach for the new `org-brain-selected-face-template`, which specifies what attributes should be added to a face when it is selected (default is all specified attributes of the `highlight` face). This allows the selected attributes to stack on the file-entry attributes. `org-brain-selected-face-template` replaces the old `org-brain-selected` face.

Finally, we add three new "local" faces: `org-brain-local-parent`, `org-brain-local-child`, and `org-brain-local-sibling`. These are not done with a template because whether an entry should be rendered as a local parent, child, or sibling is a function of the view, not the entry, and so it would be complicated for `org-brain-display-face` to determine this.

Defaults for these faces are
- File entries: italic
- Selected entries: highlighted
- Local relations: bold

The following screenshot shows this all in action:

<img width="239" alt="Screen Shot 2019-07-29 at 4 25 17 PM" src="https://user-images.githubusercontent.com/50222964/62089375-89f76b80-b21d-11e9-8480-20559604307b.png">

You can understand the faces in the following way:

- "pim" is a file entry and is the local parent of "Concept maps". Because it is a file entry, it is rendered in italic. Because it is a local parent, it is rendered bold. Note that the faces stack on each other.
- "Wikis" is a local sibling (and thus bold) and is selected (and thus also highlighted).
- TheBrain is a header entry and a local child, and is thus rendered bold but not italic.
- org-brain is a file entry and a non-local child, and is thus rendered italic but not bold.

I really appreciate the ability to quickly determine the underlying structure of the brain without having to jump straight into the .org files.

Commit notes:

- Add faces for local parents, children, and siblings
- Add face templates for file faces and selected face
- Add function to apply template attrs to appropriate faces at display time
- Remove org-brain-selected face, using template instead