### PR TITLE
More display tags

### DIFF
--- a/org-brain.el
+++ b/org-brain.el
@@ -193,6 +193,11 @@ Only applies to headline entries."
   :group 'org-brain
   :type '(string))
 
+(defcustom org-brain-each-child-on-own-line-tag "ownline"
+  "`org-mode' tag which makes each child of the headline entry be listed on its own line."
+  :group 'org-brain
+  :type '(string))
+
 (defcustom org-brain-wander-interval 3
   "Seconds between randomized entries, when using `org-brain-visualize-wander'."
   :group 'org-brain
@@ -734,6 +739,15 @@ For PREDICATE, REQUIRE-MATCH, INITIAL-INPUT, HIST, DEF and INHERIT-INPUT-METHOD 
   (ignore-errors
     (split-string
      (cdr (assoc "FILETAGS" (org-brain-keywords file-entry))) ":" t)))
+
+(defun org-brain-get-tags (entry &optional inherit)
+  "Return the tags at ENTRY. Only use local tags unless INHERIT is non-nil.
+Works for both file and headline entries."
+  (if (org-brain-filep entry)
+      (org-brain--file-tags entry)
+    (org-with-point-at
+        (org-brain-entry-marker entry)
+      (org-get-tags nil (not inherit)))))
 
 (defun org-brain--missing-id-error (entry)
   "Error message to be shown if id of ENTRY isn't found by `org-id-find'."
@@ -2263,11 +2277,7 @@ Helper function for `org-brain-visualize'."
       (dolist (parent (sort siblings (lambda (x y)
                                        (funcall org-brain-visualize-sort-function
                                                 (car x) (car y)))))
-        (let* ((parent-tags (if (org-brain-filep (car parent))
-                                (org-brain--file-tags (car parent))
-                              (org-with-point-at
-                                  (org-brain-entry-marker (car parent))
-                                (org-get-tags nil t))))
+        (let* ((parent-tags (org-brain-get-tags (car parent)))
                (children-links (unless (member org-brain-exclude-siblings-tag parent-tags)
                                  (cdr parent)))
                (sibling-middle (ceiling (/ (length children-links) 2.0)))
@@ -2345,7 +2355,10 @@ Helper function for `org-brain-visualize'."
   "Insert children of ENTRY.
 Helper function for `org-brain-visualize'."
   (when-let ((children (org-brain-children entry))
-             (fill-col (eval org-brain-child-linebreak-sexp)))
+             (fill-col (if (member org-brain-each-child-on-own-line-tag
+                                   (org-brain-get-tags entry))
+                           0
+                         (eval org-brain-child-linebreak-sexp))))
     (insert "\n\n")
     (dolist (child (sort children org-brain-visualize-sort-function))
       (let ((child-title (org-brain-title child))
@@ -2454,11 +2467,7 @@ Return the position of ENTRY in the buffer."
                                                        (funcall org-brain-visualize-sort-function
                                                                 (car x) (car y)))))
       (org-brain-insert-recursive-parent-buttons (car parent) (1- parent-max-level) (1- indent))
-      (let* ((parent-tags (if (org-brain-filep (car parent))
-                              (org-brain--file-tags (car parent))
-                            (org-with-point-at
-                                (org-brain-entry-marker (car parent))
-                              (org-get-tags nil t))) )
+      (let* ((parent-tags (org-brain-get-tags (car parent)))
              (children-links (unless (member org-brain-exclude-siblings-tag parent-tags)
                                (cdr parent))))
         (dolist (sibling (sort children-links org-brain-visualize-sort-function))

--- a/org-brain.el
+++ b/org-brain.el
@@ -1229,6 +1229,7 @@ Unless GOTO-FILE-FUNC is nil, use `pop-to-buffer-same-window' for opening the en
     (widen)
     (goto-char (marker-position marker))
     (when (org-at-heading-p)
+      (org-show-entry)
       (org-show-subtree)))
   entry)
 


### PR DESCRIPTION
This patch introduces two new tags that affect how children are displayed:

- `:ownline:` makes each child of the tagged entry appear on its own line when the tagged entry is visualized. This is akin to temporarily setting `org-brain-child-fill-column-sexp` to 0.
- `:nosort:` displays each child of the tagged node in the order the children are listed in the file. This affects the order of the node's children in both the child list (when the tagged node is being visited) and in the sibling list (when one of the tagged node's children is being visited).

The addition of these tags also convinced me to create an `org-brain-get-tags` function, since the same code to get tags started showing up in more than two places.

The patch also fixes a small display bug that occurs when you `goto` to a headline that is under a collapsed parent. Before, the entry you jump to would appear on the same line as its collapsed parent, as in

```
* Parent...**Child
Child content
```

By adding a call to `org-show-entry`, we ensure that the child appears on its own line when it is jumped to:

```
* Parent...
** Child
Child content
```