### PR TITLE
Bulk change local parent

### DIFF
--- a/org-brain.el
+++ b/org-brain.el
@@ -1452,18 +1452,22 @@ to account for the change in ENTRY's local parent."
       new-entry)))
 
 ;;;###autoload
-(defun org-brain-change-local-parent (entry parent)
+(defun org-brain-change-local-parent (&optional entry parent)
   "Refile ENTRY to be a local child of PARENT.
 Entries are relinked so existing parent-child relationships are unaffected.
 
-If called interactively, ENTRY is the current entry
-and PARENT is prompted for among the list of ENTRY's linked parents.
+If ENTRY is not supplied, the entry at point is used.
+If PARENT is not supplied, it is prompted for
+among the list of ENTRY's linked parents.
 Returns the new refiled entry."
-  (interactive
-   (let* ((this-entry (org-brain-entry-at-pt))
-          (linked-parents (org-brain--linked-property-entries this-entry "BRAIN_PARENTS"))
-          (chosen-parent (org-brain-choose-entry "Refile to parent: " linked-parents)))
-     (list this-entry chosen-parent)))
+  (interactive)
+  (unless entry (setq entry (org-brain-entry-at-pt)))
+  (unless parent (let ((linked-parents (org-brain--linked-property-entries entry "BRAIN_PARENTS")))
+                   (cl-case (length linked-parents)
+                     (0 (error "Entry \"%s\" has only one parent" (org-brain-title entry)))
+                     (1 (setq parent (car linked-parents)))
+                     (otherwise (setq parent (org-brain-choose-entry
+                                              (format "Refile \"%s\" to parent: " (org-brain-title entry)) linked-parents))))))
   (let ((old-parent (car (org-brain-local-parent entry)))
         (new-entry (org-brain-refile-to entry parent)))
     (org-brain-add-relationship old-parent new-entry)
@@ -1752,6 +1756,12 @@ Ignores selected entries that are not friends of ENTRY."
   (interactive)
   (dolist (selected org-brain-selected)
     (org-brain-delete-entry selected)))
+
+(defun org-brain-change-selected-local-parents ()
+  "Change the local parent of all the selected entries."
+  (interactive)
+  (dolist (selected org-brain-selected)
+    (org-brain-change-local-parent selected)))
 
 ;;;###autoload
 (defun org-brain-set-title (entry title)
@@ -2377,6 +2387,7 @@ TWO-WAY will be t unless called with `\\[universal-argument\\]'."
 (define-key org-brain-select-map "s" 'org-brain-clear-selected)
 (define-key org-brain-select-map "S" 'org-brain-clear-selected)
 (define-key org-brain-select-map "d" 'org-brain-delete-selected-entries)
+(define-key org-brain-select-map "l" 'org-brain-change-selected-local-parents)
 
 (define-key org-brain-visualize-mode-map "s" 'org-brain-select-dwim)
 (define-key org-brain-visualize-mode-map "S" 'org-brain-select-map)


### PR DESCRIPTION
This patch adds a bulk command to change the local parents of the selected list. I find this useful for bulk rearranging of the local org-brain topography.

Since entries in the selected list need not have any overlap in their parents, the new function simply calls `org-brain-change-local-parent` on each element of the selected list.

This also makes `org-brain-change-local-parent` have optional parameters (so that it can be called programmatically by `org-brain-change-selected-local-parents`), and refines the automatic behavior of `org-brain-change-local-parent` depending on the number of linked parents the current entry has.