### PR TITLE
Add org-brain-fallback-file-function, Fix #237

### DIFF
--- a/README.org
+++ b/README.org
@@ -175,7 +175,16 @@ to convert a file entry into a headline entry.
 
 Most of =org-mode= is tailored towards working with headlines, and because of this =org-brain= has some limitations regarding what's possible with /file entries/. The concept of both headline and file entries is confusing to some users.
 
-If you prefer to only use headline entries, you can set the variable =org-brain-include-file-entries= to =nil=. It then also makes sense to set =org-brain-file-entries-use-title= to =nil=. The headline entry name can then be formatted to not include the file entry title. =org-brain= passes two objects, the file and the headline, to the emacs [[https://www.gnu.org/software/emacs/manual/html_node/elisp/Formatting-Strings.html][format]] function. By setting =org-brain-headline-entry-name-format-string= to ="%2$s"=, =org-brain= will format the headline entry name with only the second object, the headline title.
+If you prefer to only use headline entries, you can set the variable =org-brain-include-file-entries= to =nil=. It then also makes sense to set =org-brain-file-entries-use-title= to =nil=. The headline entry name can then be formatted to not include the file entry title. =org-brain= passes two objects, the file and the headline, to the emacs [[https://www.gnu.org/software/emacs/manual/html_node/elisp/Formatting-Strings.html][format]] function. By setting =org-brain-headline-entry-name-format-string= to ="%2$s"=, =org-brain= will format the headline entry name with only the second object, the headline title. you can set =org-brain-fallback-file-function= to config headline's file. for example: place all headlines to "brain.org" when user only type headline.
+
+#+BEGIN_EXAMPLE
+(setq org-brain-fallback-file-function #'my-org-brain-fallback-file-function)
+
+(defun my-org-brain-fallback-file-function (id)
+  (if (cdr id)
+      (car id)
+    "brain"))
+#+END_EXAMPLE
 
 * Usage
 

--- a/org-brain.el
+++ b/org-brain.el
@@ -96,6 +96,17 @@ Only headlines will be considered as entries when visualizing."
   :group 'org-brain
   :type '(boolean))
 
+(defcustom org-brain-fallback-file-function #'org-brain-fallback-file-function-default
+  "Return a fallback when user type no file part.
+When user create an entry without file part, this function will
+be called with an argument:
+
+   (file-part headline-part)
+
+then return a fallback."
+  :group 'org-brain
+  :type '(function))
+
 (defcustom org-brain-show-resources t
   "Should entry resources be shown in `org-brain-visualize'?"
   :group 'org-brain
@@ -692,6 +703,10 @@ In `org-brain-visualize' just return `org-brain--vis-entry'."
                                (org-brain-headline-at))
                        (org-entry-get nil "ID")))))))
 
+(defun org-brain-fallback-file-function-default (id)
+  "The default function of `org-brain-fallback-file-function'."
+  (car id))
+
 (defun org-brain-choose-entries (prompt entries &optional predicate require-match initial-input hist def inherit-input-method)
   "PROMPT for one or more ENTRIES, separated by `org-brain-entry-separator'.
 ENTRIES can be a list, or 'all which lists all headline and file entries.
@@ -720,7 +735,9 @@ For PREDICATE, REQUIRE-MATCH, INITIAL-INPUT, HIST, DEF and INHERIT-INPUT-METOD s
                  ;; File entry
                  (progn
                    (setq id (split-string id "::" t))
-                   (let* ((entry-path (org-brain-entry-path (car id) t))
+                   (let* ((entry-path (org-brain-entry-path
+                                       (funcall org-brain-fallback-file-function id)
+                                       t))
                           (entry-file (org-brain-path-entry-name entry-path)))
                      (unless (file-exists-p entry-path)
                        (make-directory (file-name-directory entry-path) t)


### PR DESCRIPTION
If user use headline entries only, when user create an entry with out
file part.  this function can be used to get a file, all headline will
insert to this file.