### PR TITLE
Silence load

### DIFF
--- a/org-brain.el
+++ b/org-brain.el
@@ -89,7 +89,7 @@ Example: \"<--\" would add \"<--A\" in the example above."
   :group 'org-brain
   :type '(directory))
 
-(load org-brain-data-file t)
+(load org-brain-data-file t t)
 
 (defcustom org-brain-visualize-default-choices 'all
   "Which entries to choose from when using `org-brain-visualize'.


### PR DESCRIPTION
This load would ideally be evaluated lazily rather than when the file is loaded, but in any case, I'd prefer it was silent so that it did not spam the message log during start. 

I could see reasons for keeping it (like knowing that you could configure the location of the file) so maybe it should be a variable to have it be silent instead? Happy to do whatever.