### PR TITLE
Add `org-brain-show-full-entry` defvar

### DIFF
--- a/org-brain.el
+++ b/org-brain.el
@@ -940,7 +940,7 @@ Only get the body text, unless ALL-DATA is t."
         (org-remove-indentation entry-text)
       (with-temp-buffer
         (insert (org-remove-indentation entry-text))
-        (goto-char (buffer-size))
+        (goto-char (if org-brain-show-full-entry (buffer-size) (org-brain-first-headline-position)))
         (if (re-search-backward org-brain-resources-start-re nil t)
             (progn
               (end-of-line)

--- a/org-brain.el
+++ b/org-brain.el
@@ -535,6 +535,8 @@ EDGE determines if `org-brain-edge-annotation-face-template' should be used."
 
 (defvar org-brain-selected nil "List of selected org-brain entries.")
 
+(defvar org-brain-show-full-entry nil "Show the entire entry contents.")
+
 ;;;###autoload
 (defun org-brain-update-id-locations ()
   "Scan `org-brain-files' using `org-id-update-id-locations'."
@@ -901,7 +903,7 @@ Only get the body text, unless ALL-DATA is t."
             ;; File entry
             (with-temp-buffer
               (ignore-errors (insert-file-contents (org-brain-entry-path entry)))
-              (goto-char (buffer-size))
+              (goto-char (if org-brain-show-full-entry (buffer-size) (org-brain-first-headline-position)))
               (buffer-substring-no-properties
                (if all-data
                    (point-min)

--- a/org-brain.el
+++ b/org-brain.el
@@ -935,7 +935,7 @@ Only get the body text, unless ALL-DATA is t."
         (org-remove-indentation entry-text)
       (with-temp-buffer
         (insert (org-remove-indentation entry-text))
-        (goto-char (org-brain-first-headline-position))
+        (goto-char (buffer-size))
         (if (re-search-backward org-brain-resources-start-re nil t)
             (progn
               (end-of-line)

--- a/org-brain.el
+++ b/org-brain.el
@@ -128,6 +128,11 @@ Example:
   :group 'org-brain
   :type '(function))
 
+(defcustom org-brain-show-full-entry nil
+  "Always show entire entry contents?"
+  :group 'org-brain
+  :type '(boolean))
+
 (defcustom org-brain-show-resources t
   "Should entry resources be shown in `org-brain-visualize'?"
   :group 'org-brain
@@ -534,8 +539,6 @@ EDGE determines if `org-brain-edge-annotation-face-template' should be used."
 (defvar org-brain-pins nil "List of pinned org-brain entries.")
 
 (defvar org-brain-selected nil "List of selected org-brain entries.")
-
-(defvar org-brain-show-full-entry nil "Show the entire entry contents.")
 
 ;;;###autoload
 (defun org-brain-update-id-locations ()

--- a/org-brain.el
+++ b/org-brain.el
@@ -2768,7 +2768,7 @@ Helper function for `org-brain-visualize'."
   (if-let ((text (org-brain-text entry)))
       (progn
         (setq text (string-trim text))
-        (if (> (length text) 0)
+        (if (or (> (length text) 0) org-brain-show-full-entry)
             (progn
               (insert "\n\n--- Entry -------------------------------------\n\n")
               (run-hooks 'org-brain-after-visualize-hook)

--- a/org-brain.el
+++ b/org-brain.el
@@ -901,7 +901,7 @@ Only get the body text, unless ALL-DATA is t."
             ;; File entry
             (with-temp-buffer
               (ignore-errors (insert-file-contents (org-brain-entry-path entry)))
-              (goto-char (org-brain-first-headline-position))
+              (goto-char (buffer-size))
               (buffer-substring-no-properties
                (if all-data
                    (point-min)


### PR DESCRIPTION
This new variable forces org-brain to show the entire contents of file entries within the `org-brain-visualize` buffer.

This is necessary to support the new Polybrain package which uses polymode.el to allow one to edit their entries right from the visualize buffer:

https://i.imgur.com/Y4cC1rw.mp4