### PR TITLE
Make org-brain compatible with org 9.2

### DIFF
--- a/org-brain.el
+++ b/org-brain.el
@@ -3195,11 +3195,9 @@ LINK-TYPE will be \"brain\" by default."
               nil choice))))
     (let ((link (concat link-type ":"
                         (if (org-brain-filep choice) choice (nth 2 choice)))))
-      (if (version-list-< (version-to-list (org-release)) '(9 3))
-        (push link org-insert-link-history)
-        (push link org-link--insert-history)
-        )
       (if (version< (org-release) "9.3")
+          (push link org-insert-link-history)
+        (push link org-link--insert-history))
       (push `(,link ,(org-brain-title choice)) org-stored-links)
       link)))
 

--- a/org-brain.el
+++ b/org-brain.el
@@ -3199,6 +3199,7 @@ LINK-TYPE will be \"brain\" by default."
         (push link org-insert-link-history)
         (push link org-link--insert-history)
         )
+      (if (version< (org-release) "9.3")
       (push `(,link ,(org-brain-title choice)) org-stored-links)
       link)))
 

--- a/org-brain.el
+++ b/org-brain.el
@@ -3195,7 +3195,10 @@ LINK-TYPE will be \"brain\" by default."
               nil choice))))
     (let ((link (concat link-type ":"
                         (if (org-brain-filep choice) choice (nth 2 choice)))))
-      (push link org-link--insert-history)
+      (if (version-list-< (version-to-list (org-release)) '(9 3))
+        (push link org-insert-link-history)
+        (push link org-link--insert-history)
+        )
       (push `(,link ,(org-brain-title choice)) org-stored-links)
       link)))
 


### PR DESCRIPTION
`org-insert-link-history' was renamed to `org-link--insert-history' starting org release 9.3.