### PR TITLE
Fix 'helm-build-sync-source' invalid function.

### DIFF
--- a/org-brain.el
+++ b/org-brain.el
@@ -3397,12 +3397,12 @@ ENTRY should be a string; an id in the case of an headline entry."
      "Unselect" 'helm-brain--unselect))
 
   (defvar helm-brain--source
-    (helm-build-sync-source "Brain"
+    (helm-make-source "Brain" 'helm-source-sync
       :candidates #'org-brain--all-targets
       :action 'helm-brain--actions))
 
   (defvar helm-brain--fallback-source
-    (helm-build-dummy-source "New entry"
+    (helm-make-source "New entry" 'helm-source-dummy
       :action (helm-make-actions
                "Visualize" (lambda (x)
                              (org-brain-visualize (org-brain-get-entry-from-title x)))


### PR DESCRIPTION
The org-brain has no dependence on helm, so the package system ignored the loaded helm and leaved the "helm-build-sync-source" undefined when compiling. During loading process, it failed with the message "Invalid function: helm-build-sync-source". This is fixed by replacing helm-build-sync-source with helm-make-source.