### PR TITLE
[feature] add a restore function to org-brain-visualize-mode

### DIFF
--- a/README.org
+++ b/README.org
@@ -234,11 +234,15 @@ among entries.
 
 * Usage
 
-You can create new entries by =M-x org-brain-visualize= and then typing the name
-of a non-existing entry. You could also use =M-x org-brain-add-entry= if you do
-not want to visualize the new entry. Also commands which add children, parents
-and friends, or links to entries, can create new entries in the same way. Se
-/General information/ below.
+You can create new entries by =M-x org-brain-visualize= and then
+typing the name of a non-existing entry. You can go back to the
+=*org-brain*= buffer by =M-x org-brain-visualize-dwim=. It will switch
+to the =*org-brain*= buffer. If there's no such buffer, or if already
+there, run =org-brain-visualize=. You could also use =M-x
+org-brain-add-entry= if you do not want to visualize the new entry.
+Also commands which add children, parents and friends, or links to
+entries, can create new entries in the same way. Se /General
+information/ below.
 
 If you find that =org-brain= is missing entries, or list entries which doesn't
 exist, try using =M-x org-brain-update-id-locations=, which syncs the

--- a/org-brain.el
+++ b/org-brain.el
@@ -2334,12 +2334,6 @@ If run interactively, toggle following on/off."
 (defvar-local org-brain--visualize-header-end-pos 0
   "Buffer position at end of headers (history etc) in `org-brain-visualize'.")
 
-(defun org-brain-visualize-buffer-exists-p ()
-  "Check `*org-brain*' exists or not."
-  (save-window-excursion
-    (switch-to-buffer "*org-brain*")
-    (derived-mode-p 'fundamental-mode)))
-
 ;;;###autoload
 (defun org-brain-visualize (entry &optional nofocus nohistory wander)
   "View a concept map with ENTRY at the center.
@@ -2361,7 +2355,7 @@ Setting NOFOCUS to t implies also having NOHISTORY as t.
 Unless WANDER is t, `org-brain-stop-wandering' will be run."
   (interactive
    (progn
-     (if (and (not (org-brain-visualize-buffer-exists-p))
+     (if (and (get-buffer "*org-brain*")
               (not (eq major-mode 'org-brain-visualize-mode)))
          (progn (pop-to-buffer-same-window "*org-brain*")
                 (signal 'quit nil)))

--- a/org-brain.el
+++ b/org-brain.el
@@ -2334,7 +2334,7 @@ If run interactively, toggle following on/off."
 (defvar-local org-brain--visualize-header-end-pos 0
   "Buffer position at end of headers (history etc) in `org-brain-visualize'.")
 
-(defun check-org-brain-exist-p ()
+(defun org-brain-visualize-buffer-exists-p ()
   "Check `*org-brain*' exists or not."
   (save-window-excursion
     (switch-to-buffer "*org-brain*")
@@ -2361,7 +2361,7 @@ Setting NOFOCUS to t implies also having NOHISTORY as t.
 Unless WANDER is t, `org-brain-stop-wandering' will be run."
   (interactive
    (progn
-     (if (and (not (check-org-brain-exist-p))
+     (if (and (not (org-brain-visualize-buffer-exists-p))
               (not (eq major-mode 'org-brain-visualize-mode)))
          (progn (pop-to-buffer-same-window "*org-brain*")
                 (signal 'quit nil)))

--- a/org-brain.el
+++ b/org-brain.el
@@ -2373,7 +2373,6 @@ Unless WANDER is t, `org-brain-stop-wandering' will be run."
            (def-choice (unless (eq major-mode 'org-brain-visualize-mode)
                          (ignore-errors (org-brain-entry-name (org-brain-entry-at-pt))))))
        (org-brain-stop-wandering)
-       (and )
        (list
         (org-brain-choose-entry
          "Entry: "

--- a/org-brain.el
+++ b/org-brain.el
@@ -2335,7 +2335,7 @@ If run interactively, toggle following on/off."
   "Buffer position at end of headers (history etc) in `org-brain-visualize'.")
 
 (defun check-org-brain-exist-p ()
-  "check `*org-brain* exist or not."
+  "Check `*org-brain*' exists or not."
   (save-window-excursion
     (switch-to-buffer "*org-brain*")
     (derived-mode-p 'fundamental-mode)))

--- a/org-brain.el
+++ b/org-brain.el
@@ -2357,8 +2357,8 @@ Unless WANDER is t, `org-brain-stop-wandering' will be run."
    (progn
      (when (and (get-buffer "*org-brain*")
                 (not (eq major-mode 'org-brain-visualize-mode)))
-       (progn (pop-to-buffer-same-window "*org-brain*")
-              (signal 'quit nil)))
+       (pop-to-buffer-same-window "*org-brain*")
+       (signal 'quit nil))
      (org-brain-maybe-switch-brain)
      (let ((choices (cond ((equal current-prefix-arg '(4)) 'all)
                           ((equal current-prefix-arg '(16)) 'files)

--- a/org-brain.el
+++ b/org-brain.el
@@ -2361,31 +2361,31 @@ Setting NOFOCUS to t implies also having NOHISTORY as t.
 Unless WANDER is t, `org-brain-stop-wandering' will be run."
   (interactive
    (progn
-       (if (and (not (check-org-brain-exist-p))
-                (not (eq major-mode 'org-brain-visualize-mode)))
-           (progn (pop-to-buffer-same-window "*org-brain*")
-                   (signal 'quit nil)))
-       (org-brain-maybe-switch-brain)
-      (let ((choices (cond ((equal current-prefix-arg '(4)) 'all)
-                           ((equal current-prefix-arg '(16)) 'files)
-                           ((equal current-prefix-arg '(64)) 'root)
-                           (t org-brain-visualize-default-choices)))
-            (def-choice (unless (eq major-mode 'org-brain-visualize-mode)
-                          (ignore-errors (org-brain-entry-name (org-brain-entry-at-pt))))))
-        (org-brain-stop-wandering)
-        (and )
-        (list
-         (org-brain-choose-entry
-          "Entry: "
-          (cond ((equal choices 'all)
-                 'all)
-                ((equal choices 'files)
-                 (org-brain-files t))
-                ((equal choices 'root)
-                 (make-directory org-brain-path t)
-                 (mapcar #'org-brain-path-entry-name
-                         (directory-files org-brain-path t (format "\\.%s$" org-brain-files-extension)))))
-          nil nil def-choice)))))
+     (if (and (not (check-org-brain-exist-p))
+              (not (eq major-mode 'org-brain-visualize-mode)))
+         (progn (pop-to-buffer-same-window "*org-brain*")
+                (signal 'quit nil)))
+     (org-brain-maybe-switch-brain)
+     (let ((choices (cond ((equal current-prefix-arg '(4)) 'all)
+                          ((equal current-prefix-arg '(16)) 'files)
+                          ((equal current-prefix-arg '(64)) 'root)
+                          (t org-brain-visualize-default-choices)))
+           (def-choice (unless (eq major-mode 'org-brain-visualize-mode)
+                         (ignore-errors (org-brain-entry-name (org-brain-entry-at-pt))))))
+       (org-brain-stop-wandering)
+       (and )
+       (list
+        (org-brain-choose-entry
+         "Entry: "
+         (cond ((equal choices 'all)
+                'all)
+               ((equal choices 'files)
+                (org-brain-files t))
+               ((equal choices 'root)
+                (make-directory org-brain-path t)
+                (mapcar #'org-brain-path-entry-name
+                        (directory-files org-brain-path t (format "\\.%s$" org-brain-files-extension)))))
+         nil nil def-choice)))))
   (unless wander (org-brain-stop-wandering))
   (with-current-buffer (get-buffer-create "*org-brain*")
     (setq-local indent-tabs-mode nil)

--- a/org-brain.el
+++ b/org-brain.el
@@ -2334,6 +2334,12 @@ If run interactively, toggle following on/off."
 (defvar-local org-brain--visualize-header-end-pos 0
   "Buffer position at end of headers (history etc) in `org-brain-visualize'.")
 
+(defun check-org-brain-exist-p ()
+  "check `*org-brain* exist or not."
+  (save-window-excursion
+    (switch-to-buffer "*org-brain*")
+    (derived-mode-p 'fundamental-mode)))
+
 ;;;###autoload
 (defun org-brain-visualize (entry &optional nofocus nohistory wander)
   "View a concept map with ENTRY at the center.
@@ -2355,26 +2361,31 @@ Setting NOFOCUS to t implies also having NOHISTORY as t.
 Unless WANDER is t, `org-brain-stop-wandering' will be run."
   (interactive
    (progn
-     (org-brain-maybe-switch-brain)
-     (let ((choices (cond ((equal current-prefix-arg '(4)) 'all)
-                          ((equal current-prefix-arg '(16)) 'files)
-                          ((equal current-prefix-arg '(64)) 'root)
-                          (t org-brain-visualize-default-choices)))
-           (def-choice (unless (eq major-mode 'org-brain-visualize-mode)
-                         (ignore-errors (org-brain-entry-name (org-brain-entry-at-pt))))))
-       (org-brain-stop-wandering)
-       (list
-        (org-brain-choose-entry
-         "Entry: "
-         (cond ((equal choices 'all)
-                'all)
-               ((equal choices 'files)
-                (org-brain-files t))
-               ((equal choices 'root)
-                (make-directory org-brain-path t)
-                (mapcar #'org-brain-path-entry-name
-                        (directory-files org-brain-path t (format "\\.%s$" org-brain-files-extension)))))
-         nil nil def-choice)))))
+       (if (and (not (check-org-brain-exist-p))
+                (not (eq major-mode 'org-brain-visualize-mode)))
+           (progn (pop-to-buffer-same-window "*org-brain*")
+                   (signal 'quit nil)))
+       (org-brain-maybe-switch-brain)
+      (let ((choices (cond ((equal current-prefix-arg '(4)) 'all)
+                           ((equal current-prefix-arg '(16)) 'files)
+                           ((equal current-prefix-arg '(64)) 'root)
+                           (t org-brain-visualize-default-choices)))
+            (def-choice (unless (eq major-mode 'org-brain-visualize-mode)
+                          (ignore-errors (org-brain-entry-name (org-brain-entry-at-pt))))))
+        (org-brain-stop-wandering)
+        (and )
+        (list
+         (org-brain-choose-entry
+          "Entry: "
+          (cond ((equal choices 'all)
+                 'all)
+                ((equal choices 'files)
+                 (org-brain-files t))
+                ((equal choices 'root)
+                 (make-directory org-brain-path t)
+                 (mapcar #'org-brain-path-entry-name
+                         (directory-files org-brain-path t (format "\\.%s$" org-brain-files-extension)))))
+          nil nil def-choice)))))
   (unless wander (org-brain-stop-wandering))
   (with-current-buffer (get-buffer-create "*org-brain*")
     (setq-local indent-tabs-mode nil)

--- a/org-brain.el
+++ b/org-brain.el
@@ -2355,10 +2355,6 @@ Setting NOFOCUS to t implies also having NOHISTORY as t.
 Unless WANDER is t, `org-brain-stop-wandering' will be run."
   (interactive
    (progn
-     (when (and (get-buffer "*org-brain*")
-                (not (eq major-mode 'org-brain-visualize-mode)))
-       (pop-to-buffer-same-window "*org-brain*")
-       (signal 'quit nil))
      (org-brain-maybe-switch-brain)
      (let ((choices (cond ((equal current-prefix-arg '(4)) 'all)
                           ((equal current-prefix-arg '(16)) 'files)
@@ -2435,6 +2431,19 @@ Unless WANDER is t, `org-brain-stop-wandering' will be run."
       (if (or org-brain--visualize-follow org-brain-open-same-window)
           (pop-to-buffer "*org-brain*")
         (pop-to-buffer-same-window "*org-brain*")))))
+
+;;;###autoload
+(defun org-brain-visualize-dwim ()
+  "Switch to the *org-brain* buffer.
+If there's no such buffer, or if already there, run `org-brain-visualize'."
+  (interactive)
+  (if (and (not (org-brain-maybe-switch-brain))
+           (not (eq major-mode 'org-brain-visualize-mode))
+           (get-buffer "*org-brain*"))
+      (if org-brain-open-same-window
+          (pop-to-buffer "*org-brain*")
+        (pop-to-buffer-same-window "*org-brain*"))
+    (call-interactively #'org-brain-visualize)))
 
 ;;;###autoload
 (defun org-brain-visualize-entry-at-pt ()

--- a/org-brain.el
+++ b/org-brain.el
@@ -2355,10 +2355,10 @@ Setting NOFOCUS to t implies also having NOHISTORY as t.
 Unless WANDER is t, `org-brain-stop-wandering' will be run."
   (interactive
    (progn
-     (if (and (get-buffer "*org-brain*")
-              (not (eq major-mode 'org-brain-visualize-mode)))
-         (progn (pop-to-buffer-same-window "*org-brain*")
-                (signal 'quit nil)))
+     (when (and (get-buffer "*org-brain*")
+                (not (eq major-mode 'org-brain-visualize-mode)))
+       (progn (pop-to-buffer-same-window "*org-brain*")
+              (signal 'quit nil)))
      (org-brain-maybe-switch-brain)
      (let ((choices (cond ((equal current-prefix-arg '(4)) 'all)
                           ((equal current-prefix-arg '(16)) 'files)


### PR DESCRIPTION
Like how user calls "Info" mode, if there is no `org-brain-visualize`
buffer exists, everything is the same as before. If there
is *org-brain* buffer exists, switch to *org-brain*.

This feature is helpful for users who need constantly switch between
the Org-brain and the working documents.

The `quit` message can be further improved by using a better-quitting
strategy. However, the function right now can achieve this feature. It
is unclear what side effects will bring to the current packages.
Careful review should be taken.