### PR TITLE
Fix: missing-id-error: Fetch entry-name only when entry is non-nil

### DIFF
--- a/org-brain.el
+++ b/org-brain.el
@@ -1033,7 +1033,7 @@ Only works on headline entries."
 (defun org-brain--missing-id-error (entry)
   "Error message to be shown if id of ENTRY isn't found by `org-id-find'."
   (error "Couldn't find entry %s, try running org-brain-update-id-locations. "
-         (org-brain-entry-name entry)))
+         (when entry (org-brain-entry-name entry))))
 
 (defun org-brain-entry-marker (entry)
   "Get marker to ENTRY."


### PR DESCRIPTION
Fixes the problem where changing local parents (using `M r` - `org-brain-refile`) always causes a backtrace.

I don't know why the entry is nil in the first place, which is something I will investigate further as time permits, but in any case this safeguard looks good to have.