### PR TITLE
Fix org-link issue in entry section

### DIFF
--- a/org-brain.el
+++ b/org-brain.el
@@ -3283,7 +3283,9 @@ Return the position of ENTRY in the buffer."
     :head-matcher "^[─-]\\{3\\} Entry [─-]+\n"
     :tail-matcher "\\'"
     :head-mode 'host
-    :tail-mode 'host)
+    :tail-mode 'host
+    :init-functions '((lambda (_)
+                        (setq-local org-fold-core-style 'overlays))))
 
   (define-polymode org-brain-polymode
     :hostmode 'org-brain-poly-hostmode

--- a/org-brain.el
+++ b/org-brain.el
@@ -3125,12 +3125,12 @@ Helper function for `org-brain-visualize'."
               (run-hooks 'org-brain-after-visualize-hook)
               (insert (with-temp-buffer
                         (insert text)
-                        (let ((org-fold-core-style 'overlays))
-                          (delay-mode-hooks
-                            (org-mode)
-                            (setq-local org-pretty-entities t)
-                            (font-lock-ensure (point-min) (point-max))
-                            (buffer-string)))))
+                        (delay-mode-hooks
+                          (org-mode)
+                          (setq-local org-pretty-entities t
+                                      org-fold-core-style 'overlays)
+                          (font-lock-ensure (point-min) (point-max))
+                          (buffer-string))))
               (run-hooks 'org-brain-visualize-text-hook))
           (run-hooks 'org-brain-after-visualize-hook)))
     (run-hooks 'org-brain-after-visualize-hook)))

--- a/org-brain.el
+++ b/org-brain.el
@@ -3125,11 +3125,12 @@ Helper function for `org-brain-visualize'."
               (run-hooks 'org-brain-after-visualize-hook)
               (insert (with-temp-buffer
                         (insert text)
-                        (delay-mode-hooks
-                          (org-mode)
-                          (setq-local org-pretty-entities t)
-                          (font-lock-ensure (point-min) (point-max))
-                          (buffer-string))))
+                        (let ((org-fold-core-style 'overlays))
+                          (delay-mode-hooks
+                            (org-mode)
+                            (setq-local org-pretty-entities t)
+                            (font-lock-ensure (point-min) (point-max))
+                            (buffer-string)))))
               (run-hooks 'org-brain-visualize-text-hook))
           (run-hooks 'org-brain-after-visualize-hook)))
     (run-hooks 'org-brain-after-visualize-hook)))


### PR DESCRIPTION
Org 9.6 makes links in org-fold broken. So it needs to add `overlay` style.

This issue already happened in other org-mode based packages. e.g: org-roam

Fix #382 